### PR TITLE
Feat connector server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,18 +4319,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,9 +2131,9 @@ dependencies = [
 [[package]]
 name = "libsoxr-sys"
 version = "0.1.4"
-source = "git+https://github.com/giangndm/libsoxr-sys.git?rev=994fb732a4237d65d241fc83771dd24f4c25e8de#994fb732a4237d65d241fc83771dd24f4c25e8de"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cffdc8b3b64759d2e95e3236fa6bf85fef226bf57023fa9273ec60edea8fbce"
 dependencies = [
- "cmake",
  "pkg-config",
 ]
 

--- a/packages/cluster/src/define/endpoint.rs
+++ b/packages/cluster/src/define/endpoint.rs
@@ -1,8 +1,8 @@
 use transport::TrackId;
 
 use crate::{
-    ClusterEndpointError, ClusterLocalTrackIncomingEvent, ClusterLocalTrackOutgoingEvent, ClusterPeerId, ClusterRemoteTrackIncomingEvent, ClusterRemoteTrackOutgoingEvent, ClusterTrackMeta,
-    ClusterTrackName, ClusterTrackUuid,
+    rpc::connector::MediaEndpointLogRequest, ClusterEndpointError, ClusterLocalTrackIncomingEvent, ClusterLocalTrackOutgoingEvent, ClusterPeerId, ClusterRemoteTrackIncomingEvent,
+    ClusterRemoteTrackOutgoingEvent, ClusterTrackMeta, ClusterTrackName, ClusterTrackUuid,
 };
 
 #[async_trait::async_trait]
@@ -19,6 +19,7 @@ pub enum ClusterEndpointOutgoingEvent {
     UnsubscribePeer(ClusterPeerId),
     LocalTrackEvent(TrackId, ClusterLocalTrackOutgoingEvent),
     RemoteTrackEvent(TrackId, ClusterTrackUuid, ClusterRemoteTrackOutgoingEvent),
+    MediaEndpointLog(MediaEndpointLogRequest),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/packages/cluster/src/define/rpc.rs
+++ b/packages/cluster/src/define/rpc.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+pub mod connector;
 pub mod gateway;
 pub mod general;
 pub mod webrtc;
@@ -57,3 +58,5 @@ pub const RPC_WHEP_CONNECT: &str = "RPC_WHEP_CONNECT";
 
 pub const RPC_NODE_PING: &str = "RPC_NODE_PING";
 pub const RPC_NODE_HEALTHCHECK: &str = "RPC_NODE_HEALTHCHECK";
+
+pub const RPC_MEDIA_ENDPOINT_LOG: &str = "RPC_MEDIA_ENDPOINT_LOG";

--- a/packages/cluster/src/define/rpc/connector.rs
+++ b/packages/cluster/src/define/rpc/connector.rs
@@ -1,16 +1,17 @@
 use std::net::SocketAddr;
 
 use atm0s_sdn::NodeId;
+use media_utils::F32;
 use proc_macro::{IntoVecU8, TryFromSliceU8};
 use serde::{Deserialize, Serialize};
 use transport::MediaKind;
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub enum MediaStreamIssueType {
-    Connectivity { mos: f32, lost_percents: f32, jitter_ms: f32, rtt_ms: u32 },
+    Connectivity { mos: F32<2>, lost_percents: F32<2>, jitter_ms: F32<2>, rtt_ms: u32 },
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub enum MediaEndpointEvent {
     Routing {
         user_agent: String,
@@ -49,7 +50,7 @@ pub enum MediaEndpointEvent {
         sent_bytes: u64,
         received_bytes: u64,
         duration_ms: u64,
-        rtt: f32,
+        rtt: F32<2>,
     },
     SessionStats {
         received_bytes: u64,
@@ -60,7 +61,7 @@ pub enum MediaEndpointEvent {
     },
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub enum MediaReceiveStreamEvent {
     StreamStarted {
         name: String,
@@ -81,10 +82,10 @@ pub enum MediaReceiveStreamEvent {
         limit_bitrate: u32,
         received_bytes: u64,
         freeze: bool,
-        mos: Option<f32>,
+        mos: Option<F32<2>>,
         rtt: Option<u32>,
-        jitter: Option<f32>,
-        lost: Option<f32>,
+        jitter: Option<F32<2>>,
+        lost: Option<F32<2>>,
     },
     StreamEnded {
         name: String,
@@ -92,14 +93,14 @@ pub enum MediaReceiveStreamEvent {
         sent_bytes: u64,
         freeze_count: u32,
         duration_ms: u64,
-        mos: Option<(f32, f32, f32)>,
-        rtt: Option<(f32, f32, f32)>,
-        jitter: Option<(f32, f32, f32)>,
-        lost: Option<(f32, f32, f32)>,
+        mos: Option<(F32<2>, F32<2>, F32<2>)>,
+        rtt: Option<(F32<2>, F32<2>, F32<2>)>,
+        jitter: Option<(F32<2>, F32<2>, F32<2>)>,
+        lost: Option<(F32<2>, F32<2>, F32<2>)>,
     },
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub enum MediaSendStreamEvent {
     StreamStarted {
         name: String,
@@ -117,10 +118,10 @@ pub enum MediaSendStreamEvent {
         kind: MediaKind,
         sent_bytes: u64,
         freeze: bool,
-        mos: Option<f32>,
+        mos: Option<F32<2>>,
         rtt: Option<u32>,
-        jitter: Option<f32>,
-        lost: Option<f32>,
+        jitter: Option<F32<2>>,
+        lost: Option<F32<2>>,
     },
     StreamEnded {
         name: String,
@@ -128,19 +129,19 @@ pub enum MediaSendStreamEvent {
         received_bytes: u64,
         duration_ms: u64,
         freeze_count: u32,
-        mos: Option<(f32, f32, f32)>,
-        rtt: Option<(f32, f32, f32)>,
-        jitter: Option<(f32, f32, f32)>,
-        lost: Option<(f32, f32, f32)>,
+        mos: Option<(F32<2>, F32<2>, F32<2>)>,
+        rtt: Option<(F32<2>, F32<2>, F32<2>)>,
+        jitter: Option<(F32<2>, F32<2>, F32<2>)>,
+        lost: Option<(F32<2>, F32<2>, F32<2>)>,
     },
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize, IntoVecU8, TryFromSliceU8)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize, IntoVecU8, TryFromSliceU8)]
 pub enum MediaEndpointLogRequest {
     SessionEvent {
         ip: String,
         version: Option<String>,
-        location: Option<(f64, f64)>,
+        location: Option<(F32<2>, F32<2>)>,
         token: Vec<u8>,
         ts: u64,
         session_uuid: u64,

--- a/packages/cluster/src/define/rpc/connector.rs
+++ b/packages/cluster/src/define/rpc/connector.rs
@@ -1,0 +1,164 @@
+use std::net::SocketAddr;
+
+use atm0s_sdn::NodeId;
+use proc_macro::{IntoVecU8, TryFromSliceU8};
+use serde::{Deserialize, Serialize};
+use transport::MediaKind;
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum MediaStreamIssueType {
+    Connectivity { mos: f32, lost_percents: f32, jitter_ms: f32, rtt_ms: u32 },
+}
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum MediaEndpointEvent {
+    Routing {
+        user_agent: String,
+        gateway_node_id: NodeId,
+    },
+    RoutingError {
+        reason: String,
+        gateway_node_id: NodeId,
+        media_node_ids: Vec<NodeId>,
+    },
+    Routed {
+        media_node_id: NodeId,
+        after_ms: u32,
+    },
+    Connecting {
+        user_agent: String,
+        remote: Option<SocketAddr>,
+    },
+    ConnectError {
+        remote: Option<SocketAddr>,
+        error_code: String,
+        error_message: String,
+    },
+    Connected {
+        after_ms: u32,
+        remote: Option<SocketAddr>,
+    },
+    Reconnecting {
+        reason: String,
+    },
+    Reconnected {
+        remote: Option<SocketAddr>,
+    },
+    Disconnected {
+        error: Option<String>,
+        sent_bytes: u64,
+        received_bytes: u64,
+        duration_ms: u64,
+        rtt: f32,
+    },
+    SessionStats {
+        received_bytes: u64,
+        receive_limit_bitrate: u32,
+        sent_bytes: u64,
+        send_est_bitrate: u32,
+        rtt: u16,
+    },
+}
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum MediaReceiveStreamEvent {
+    StreamStarted {
+        name: String,
+        kind: MediaKind,
+        remote_peer: String,
+        remote_stream: String,
+    },
+    StreamIssue {
+        name: String,
+        kind: MediaKind,
+        remote_peer: String,
+        remote_stream: String,
+        issue: MediaStreamIssueType,
+    },
+    StreamStats {
+        name: String,
+        kind: MediaKind,
+        limit_bitrate: u32,
+        received_bytes: u64,
+        freeze: bool,
+        mos: Option<f32>,
+        rtt: Option<u32>,
+        jitter: Option<f32>,
+        lost: Option<f32>,
+    },
+    StreamEnded {
+        name: String,
+        kind: MediaKind,
+        sent_bytes: u64,
+        freeze_count: u32,
+        duration_ms: u64,
+        mos: Option<(f32, f32, f32)>,
+        rtt: Option<(f32, f32, f32)>,
+        jitter: Option<(f32, f32, f32)>,
+        lost: Option<(f32, f32, f32)>,
+    },
+}
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum MediaSendStreamEvent {
+    StreamStarted {
+        name: String,
+        kind: MediaKind,
+        meta: String,
+        scaling: String,
+    },
+    StreamIssue {
+        name: String,
+        kind: MediaKind,
+        issue: MediaStreamIssueType,
+    },
+    StreamStats {
+        name: String,
+        kind: MediaKind,
+        sent_bytes: u64,
+        freeze: bool,
+        mos: Option<f32>,
+        rtt: Option<u32>,
+        jitter: Option<f32>,
+        lost: Option<f32>,
+    },
+    StreamEnded {
+        name: String,
+        kind: MediaKind,
+        received_bytes: u64,
+        duration_ms: u64,
+        freeze_count: u32,
+        mos: Option<(f32, f32, f32)>,
+        rtt: Option<(f32, f32, f32)>,
+        jitter: Option<(f32, f32, f32)>,
+        lost: Option<(f32, f32, f32)>,
+    },
+}
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize, IntoVecU8, TryFromSliceU8)]
+pub enum MediaEndpointLogRequest {
+    SessionEvent {
+        ip: String,
+        version: Option<String>,
+        location: Option<(f64, f64)>,
+        token: Vec<u8>,
+        ts: u64,
+        session_uuid: u64,
+        event: MediaEndpointEvent,
+    },
+    ReceiveStreamEvent {
+        token: Vec<u8>,
+        ts: u64,
+        session_uuid: u64,
+        event: MediaReceiveStreamEvent,
+    },
+    SendStreamEvent {
+        token: Vec<u8>,
+        ts: u64,
+        session_uuid: u64,
+        event: MediaSendStreamEvent,
+    },
+}
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize, IntoVecU8, TryFromSliceU8)]
+pub struct MediaEndpointLogResponse {}

--- a/packages/cluster/src/define/rpc/webrtc.rs
+++ b/packages/cluster/src/define/rpc/webrtc.rs
@@ -23,6 +23,9 @@ pub struct WebrtcConnectRequestSender {
 
 #[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
 pub struct WebrtcConnectRequest {
+    pub session_uuid: Option<u64>,
+    pub ip_addr: Option<String>,
+    pub user_agent: Option<String>,
     pub version: Option<String>,
     pub room: String,
     pub peer: String,

--- a/packages/cluster/src/define/rpc/whep.rs
+++ b/packages/cluster/src/define/rpc/whep.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
 pub struct WhepConnectRequest {
+    pub session_uuid: u64,
+    pub ip_addr: String,
+    pub user_agent: String,
     pub token: String,
     pub sdp: Option<String>,
     pub compressed_sdp: Option<Vec<u8>>,

--- a/packages/cluster/src/define/rpc/whip.rs
+++ b/packages/cluster/src/define/rpc/whip.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
 pub struct WhipConnectRequest {
+    pub session_uuid: u64,
+    pub ip_addr: String,
+    pub user_agent: String,
     pub token: String,
     pub sdp: Option<String>,
     pub compressed_sdp: Option<Vec<u8>>,

--- a/packages/cluster/src/implement/server.rs
+++ b/packages/cluster/src/implement/server.rs
@@ -4,7 +4,7 @@ use crate::Cluster;
 use atm0s_sdn::{
     convert_enum, KeyValueBehavior, KeyValueBehaviorEvent, KeyValueHandlerEvent, KeyValueSdk, KeyValueSdkEvent, LayersSpreadRouterSyncBehavior, LayersSpreadRouterSyncBehaviorEvent,
     LayersSpreadRouterSyncHandlerEvent, ManualBehavior, ManualBehaviorConf, ManualBehaviorEvent, ManualHandlerEvent, NetworkPlane, NetworkPlaneConfig, NodeAddr, NodeAddrBuilder, NodeId, Protocol,
-    PubsubSdk, PubsubServiceBehaviour, PubsubServiceBehaviourEvent, PubsubServiceHandlerEvent, RpcBox, SharedRouter, SystemTimer, UdpTransport,
+    PubsubSdk, PubsubServiceBehaviour, PubsubServiceBehaviourEvent, PubsubServiceHandlerEvent, RpcBox, RpcEmitter, SharedRouter, SystemTimer, UdpTransport,
 };
 
 use super::{endpoint, rpc::RpcEndpointSdn};
@@ -39,6 +39,7 @@ pub struct ServerSdn {
     join_handler: Option<async_std::task::JoinHandle<()>>,
     pubsub_sdk: PubsubSdk,
     kv_sdk: KeyValueSdk,
+    rpc_emitter: RpcEmitter,
 }
 
 impl ServerSdn {
@@ -92,6 +93,7 @@ impl ServerSdn {
                 pubsub_sdk,
                 kv_sdk,
                 join_handler: Some(join_handler),
+                rpc_emitter: rpc_box.emitter(),
             },
             RpcEndpointSdn { rpc_box },
         )
@@ -104,7 +106,7 @@ impl Cluster<endpoint::ClusterEndpointSdn> for ServerSdn {
     }
 
     fn build(&mut self, room_id: &str, peer_id: &str) -> endpoint::ClusterEndpointSdn {
-        endpoint::ClusterEndpointSdn::new(room_id, peer_id, self.pubsub_sdk.clone(), self.kv_sdk.clone())
+        endpoint::ClusterEndpointSdn::new(room_id, peer_id, self.pubsub_sdk.clone(), self.kv_sdk.clone(), self.rpc_emitter.clone())
     }
 }
 

--- a/packages/endpoint/src/lib.rs
+++ b/packages/endpoint/src/lib.rs
@@ -1,7 +1,9 @@
 mod endpoint_pre;
 mod endpoint_wrap;
+mod middleware;
 pub mod rpc;
 
 pub use endpoint_pre::MediaEndpointPreconditional;
 pub use endpoint_wrap::{BitrateLimiterType, MediaEndpoint, MediaEndpointOutput};
+pub use middleware::{MediaEndpointMiddleware, MediaEndpointMiddlewareOutput};
 pub use rpc::{EndpointRpcIn, EndpointRpcOut, RpcRequest, RpcResponse};

--- a/packages/endpoint/src/middleware.rs
+++ b/packages/endpoint/src/middleware.rs
@@ -1,0 +1,26 @@
+use cluster::{ClusterEndpointIncomingEvent, ClusterEndpointOutgoingEvent};
+use transport::{TransportError, TransportIncomingEvent, TransportOutgoingEvent};
+
+use crate::{
+    rpc::{LocalTrackRpcIn, LocalTrackRpcOut, RemoteTrackRpcIn, RemoteTrackRpcOut},
+    EndpointRpcIn, EndpointRpcOut,
+};
+
+pub mod logger;
+
+pub enum MediaEndpointMiddlewareOutput {
+    Endpoint(TransportOutgoingEvent<EndpointRpcOut, RemoteTrackRpcOut, LocalTrackRpcOut>),
+    Cluster(ClusterEndpointOutgoingEvent),
+}
+
+pub trait MediaEndpointMiddleware: Send + Sync {
+    fn on_start(&mut self, now_ms: u64);
+    fn on_tick(&mut self, now_ms: u64);
+    /// return true if event is consumed
+    fn on_transport(&mut self, now_ms: u64, event: &TransportIncomingEvent<EndpointRpcIn, RemoteTrackRpcIn, LocalTrackRpcIn>) -> bool;
+    /// return true if event is consumed
+    fn on_transport_error(&mut self, now_ms: u64, error: &TransportError) -> bool;
+    /// return true if event is consumed
+    fn on_cluster(&mut self, now_ms: u64, event: &ClusterEndpointIncomingEvent) -> bool;
+    fn pop_action(&mut self) -> Option<MediaEndpointMiddlewareOutput>;
+}

--- a/packages/endpoint/src/middleware/logger.rs
+++ b/packages/endpoint/src/middleware/logger.rs
@@ -1,0 +1,137 @@
+use std::collections::VecDeque;
+
+use cluster::rpc::connector::{MediaEndpointEvent, MediaEndpointLogRequest};
+use media_utils::F32;
+use transport::{TransportError, TransportIncomingEvent, TransportStateEvent};
+
+use crate::{MediaEndpointMiddleware, MediaEndpointMiddlewareOutput};
+
+pub struct MediaEndpointEventLogger {
+    started_ms: Option<u64>,
+    outputs: VecDeque<crate::MediaEndpointMiddlewareOutput>,
+}
+
+impl MediaEndpointEventLogger {
+    pub fn new() -> Self {
+        Self {
+            outputs: VecDeque::new(),
+            started_ms: None,
+        }
+    }
+
+    fn build_event(&self, now_ms: u64, event: MediaEndpointEvent) -> MediaEndpointMiddlewareOutput {
+        log::info!("sending event out to connector {:?}", event);
+        let event = MediaEndpointLogRequest::SessionEvent {
+            ip: "127.0.0.1".to_string(), //TODO
+            version: None,
+            location: None,
+            token: vec![],
+            ts: now_ms,
+            session_uuid: 0, //TODO
+            event,
+        };
+        MediaEndpointMiddlewareOutput::Cluster(cluster::ClusterEndpointOutgoingEvent::MediaEndpointLog(event))
+    }
+}
+
+impl MediaEndpointMiddleware for MediaEndpointEventLogger {
+    fn on_start(&mut self, now_ms: u64) {
+        self.started_ms = Some(now_ms);
+        self.outputs.push_back(self.build_event(
+            now_ms,
+            MediaEndpointEvent::Connecting {
+                user_agent: "TODO".to_string(), //TODO
+                remote: None,                   //TODO
+            },
+        ));
+    }
+
+    fn on_tick(&mut self, _now_ms: u64) {}
+
+    /// return true if event is consumed
+    fn on_transport(&mut self, now_ms: u64, event: &TransportIncomingEvent<crate::EndpointRpcIn, crate::rpc::RemoteTrackRpcIn, crate::rpc::LocalTrackRpcIn>) -> bool {
+        match event {
+            TransportIncomingEvent::State(state) => match state {
+                TransportStateEvent::Connected => {
+                    self.outputs.push_back(self.build_event(
+                        now_ms,
+                        MediaEndpointEvent::Connected {
+                            after_ms: (now_ms - self.started_ms.expect("Should has started")) as u32,
+                            remote: None, //TODO
+                        },
+                    ));
+                }
+                TransportStateEvent::Reconnecting => {
+                    self.outputs.push_back(self.build_event(
+                        now_ms,
+                        MediaEndpointEvent::Reconnecting {
+                            reason: "TODO".to_string(), //TODO
+                        },
+                    ));
+                }
+                TransportStateEvent::Reconnected => {
+                    self.outputs.push_back(self.build_event(
+                        now_ms,
+                        MediaEndpointEvent::Reconnected {
+                            remote: None, //TODO
+                        },
+                    ));
+                }
+                TransportStateEvent::Disconnected => {
+                    self.outputs.push_back(self.build_event(
+                        now_ms,
+                        MediaEndpointEvent::Disconnected {
+                            error: None,
+                            duration_ms: now_ms - self.started_ms.expect("Should has started"),
+                            received_bytes: 0,  //TODO
+                            rtt: F32::new(0.0), //TODO
+                            sent_bytes: 0,      //TODO
+                        },
+                    ));
+                }
+            },
+            _ => {}
+        }
+        false
+    }
+
+    /// return true if event is consumed
+    fn on_transport_error(&mut self, now_ms: u64, error: &TransportError) -> bool {
+        match error {
+            TransportError::ConnectError(_) => {
+                self.outputs.push_back(self.build_event(
+                    now_ms,
+                    MediaEndpointEvent::ConnectError {
+                        remote: None,                      //TODO
+                        error_code: "TODO".to_string(),    //TODO
+                        error_message: "TODO".to_string(), //TODO
+                    },
+                ));
+            }
+            TransportError::ConnectionError(_) => {
+                self.outputs.push_back(self.build_event(
+                    now_ms,
+                    MediaEndpointEvent::Disconnected {
+                        error: Some("TIMEOUT".to_string()), //TODO
+                        duration_ms: now_ms - self.started_ms.expect("Should has started"),
+                        received_bytes: 0,  //TODO
+                        rtt: F32::new(0.0), //TODO
+                        sent_bytes: 0,      //TODO
+                    },
+                ));
+            }
+            _ => {}
+        }
+
+        false
+    }
+
+    /// return true if event is consumed
+    fn on_cluster(&mut self, _now_ms: u64, _event: &cluster::ClusterEndpointIncomingEvent) -> bool {
+        false
+    }
+
+    fn pop_action(&mut self) -> Option<crate::MediaEndpointMiddlewareOutput> {
+        self.outputs.pop_back()
+    }
+}

--- a/packages/media-utils/src/float.rs
+++ b/packages/media-utils/src/float.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+/// This store float f32 as u32, and can be used as key in HashMap
+/// ACCURACY is the number of digits after the decimal point
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct F32<const ACCURACY: usize>(u32);
+
+impl<const ACCURACY: usize> F32<ACCURACY> {
+    pub fn new(value: f32) -> Self {
+        Self((value * 10_f32.powi(ACCURACY as i32)) as u32)
+    }
+
+    pub fn value(&self) -> f32 {
+        self.0 as f32 / 10_f32.powi(ACCURACY as i32)
+    }
+}

--- a/packages/media-utils/src/lib.rs
+++ b/packages/media-utils/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod float;
 mod hash;
 mod map;
 mod req_res;
@@ -11,6 +12,7 @@ mod tracking;
 mod ts_rewriter;
 
 pub use error::*;
+pub use float::*;
 pub use hash::*;
 pub use map::*;
 pub use req_res::*;

--- a/servers/media-server/Cargo.toml
+++ b/servers/media-server/Cargo.toml
@@ -31,9 +31,10 @@ metrics-dashboard = { version = "0.1.3", features = ["system"] }
 metrics = "0.21.1"
 
 [features]
-default = ["embed-samples", "gateway", "webrtc", "rtmp", "sip"]
+default = ["embed-samples", "gateway", "webrtc", "rtmp", "sip", "connector"]
 embed-samples = ["rust-embed"]
 webrtc = ["transport-webrtc"]
 rtmp = ["transport-rtmp"]
 sip = ["rsip", "transport-sip"]
 gateway = []
+connector = []

--- a/servers/media-server/src/server.rs
+++ b/servers/media-server/src/server.rs
@@ -9,6 +9,8 @@ const METRIC_SESSIONS_COUNT: &str = "media_server.sessions.count";
 const METRIC_SESSIONS_LIVE: &str = "media_server.sessions.live";
 const METRIC_SESSIONS_MAX: &str = "media_server.sessions.max";
 
+#[cfg(feature = "connector")]
+pub mod connector;
 #[cfg(feature = "gateway")]
 pub mod gateway;
 #[cfg(feature = "rtmp")]

--- a/servers/media-server/src/server/connector.rs
+++ b/servers/media-server/src/server/connector.rs
@@ -1,0 +1,62 @@
+use clap::Parser;
+use cluster::{
+    rpc::{connector::MediaEndpointLogResponse, RpcEmitter, RpcEndpoint, RpcRequest},
+    Cluster, ClusterEndpoint,
+};
+use futures::{select, FutureExt};
+use metrics_dashboard::build_dashboard_route;
+use poem::Route;
+use poem_openapi::OpenApiService;
+
+use crate::rpc::http::HttpRpcServer;
+
+mod rpc;
+
+use self::rpc::{cluster::ConnectorClusterRpc, http::ConnectorHttpApis, RpcEvent};
+
+/// Media Server Webrtc
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct ConnectorArgs {}
+
+pub async fn run_connector_server<C, CR, RPC, REQ, EMITTER>(http_port: u16, _opts: ConnectorArgs, _cluster: C, rpc_endpoint: RPC) -> Result<(), &'static str>
+where
+    C: Cluster<CR> + Send + 'static,
+    CR: ClusterEndpoint + Send + 'static,
+    RPC: RpcEndpoint<REQ, EMITTER>,
+    REQ: RpcRequest + Send + 'static,
+    EMITTER: RpcEmitter + Send + 'static,
+{
+    let mut rpc_endpoint = ConnectorClusterRpc::new(rpc_endpoint);
+    let mut http_server: HttpRpcServer<RpcEvent> = crate::rpc::http::HttpRpcServer::new(http_port);
+
+    let api_service = OpenApiService::new(ConnectorHttpApis, "Connector Server", "1.0.0").server("http://localhost:3000");
+    let ui = api_service.swagger_ui();
+    let spec = api_service.spec();
+
+    let route = Route::new()
+        .nest("/", api_service)
+        .nest("/dashboard/", build_dashboard_route())
+        .nest("/ui/", ui)
+        .at("/spec/", poem::endpoint::make_sync(move |_| spec.clone()));
+
+    http_server.start(route).await;
+
+    loop {
+        let rpc = select! {
+            rpc = http_server.recv().fuse() => {
+                rpc.ok_or("HTTP_SERVER_ERROR")?
+            },
+            rpc = rpc_endpoint.recv().fuse() => {
+                rpc.ok_or("CLUSTER_RPC_ERROR")?
+            }
+        };
+
+        match rpc {
+            RpcEvent::MediaEndpointLog(req) => {
+                log::info!("On media endpoint log {:?}", req.param());
+                req.answer(Ok(MediaEndpointLogResponse {}));
+            }
+        }
+    }
+}

--- a/servers/media-server/src/server/connector.rs
+++ b/servers/media-server/src/server/connector.rs
@@ -55,6 +55,7 @@ where
         match rpc {
             RpcEvent::MediaEndpointLog(req) => {
                 log::info!("On media endpoint log {:?}", req.param());
+                //TODO emit event to external queue: NATS, Kafka, etc
                 req.answer(Ok(MediaEndpointLogResponse {}));
             }
         }

--- a/servers/media-server/src/server/connector/rpc.rs
+++ b/servers/media-server/src/server/connector/rpc.rs
@@ -1,0 +1,9 @@
+use ::cluster::rpc::connector::{MediaEndpointLogRequest, MediaEndpointLogResponse};
+use ::cluster::rpc::RpcReqRes;
+
+pub mod cluster;
+pub mod http;
+
+pub enum RpcEvent {
+    MediaEndpointLog(Box<dyn RpcReqRes<MediaEndpointLogRequest, MediaEndpointLogResponse>>),
+}

--- a/servers/media-server/src/server/connector/rpc/cluster.rs
+++ b/servers/media-server/src/server/connector/rpc/cluster.rs
@@ -1,0 +1,36 @@
+use std::marker::PhantomData;
+
+use cluster::rpc::{RpcEmitter, RpcEndpoint, RpcRequest, RPC_MEDIA_ENDPOINT_LOG};
+
+use super::RpcEvent;
+
+pub struct ConnectorClusterRpc<RPC: RpcEndpoint<Req, Emitter>, Req: RpcRequest, Emitter: RpcEmitter> {
+    _tmp: PhantomData<(Req, Emitter)>,
+    rpc: RPC,
+}
+
+impl<RPC: RpcEndpoint<Req, Emitter>, Req: RpcRequest, Emitter: RpcEmitter> ConnectorClusterRpc<RPC, Req, Emitter> {
+    pub fn new(rpc: RPC) -> Self {
+        Self { _tmp: Default::default(), rpc }
+    }
+
+    pub fn emitter(&mut self) -> Emitter {
+        self.rpc.emitter()
+    }
+
+    pub async fn recv(&mut self) -> Option<RpcEvent> {
+        loop {
+            let event = self.rpc.recv().await?;
+            match event.cmd() {
+                RPC_MEDIA_ENDPOINT_LOG => {
+                    if let Some(req) = event.parse() {
+                        return Some(RpcEvent::MediaEndpointLog(req));
+                    }
+                }
+                _ => {
+                    event.error("NOT_SUPPORTED_CMD");
+                }
+            }
+        }
+    }
+}

--- a/servers/media-server/src/server/connector/rpc/http.rs
+++ b/servers/media-server/src/server/connector/rpc/http.rs
@@ -1,0 +1,6 @@
+use poem_openapi::OpenApi;
+
+pub struct ConnectorHttpApis;
+
+#[OpenApi]
+impl ConnectorHttpApis {}

--- a/servers/media-server/src/server/gateway.rs
+++ b/servers/media-server/src/server/gateway.rs
@@ -4,18 +4,16 @@ use async_std::stream::StreamExt;
 use clap::Parser;
 use cluster::{
     rpc::{
-        gateway::{parse_conn_id, NodeHealthcheckRequest, NodeHealthcheckResponse},
+        gateway::parse_conn_id,
         general::{MediaEndpointCloseRequest, MediaEndpointCloseResponse},
-        webrtc::{WebrtcConnectRequest, WebrtcConnectResponse, WebrtcPatchRequest, WebrtcPatchResponse, WebrtcRemoteIceRequest, WebrtcRemoteIceResponse},
-        whep::{WhepConnectRequest, WhepConnectResponse},
-        whip::{WhipConnectRequest, WhipConnectResponse},
-        RpcEmitter, RpcEndpoint, RpcRequest, RPC_MEDIA_ENDPOINT_CLOSE, RPC_NODE_HEALTHCHECK, RPC_WEBRTC_CONNECT, RPC_WEBRTC_ICE, RPC_WEBRTC_PATCH, RPC_WHEP_CONNECT, RPC_WHIP_CONNECT,
+        webrtc::{WebrtcPatchRequest, WebrtcPatchResponse, WebrtcRemoteIceRequest, WebrtcRemoteIceResponse},
+        RpcEmitter, RpcEndpoint, RpcRequest, RPC_MEDIA_ENDPOINT_CLOSE, RPC_WEBRTC_CONNECT, RPC_WEBRTC_ICE, RPC_WEBRTC_PATCH, RPC_WHEP_CONNECT, RPC_WHIP_CONNECT,
     },
     Cluster, ClusterEndpoint, MEDIA_SERVER_SERVICE,
 };
 use futures::{select, FutureExt};
 use media_utils::{SystemTimer, Timer};
-use metrics::{describe_counter, increment_counter};
+use metrics::describe_counter;
 use metrics_dashboard::build_dashboard_route;
 use poem::Route;
 use poem_openapi::OpenApiService;
@@ -42,56 +40,25 @@ use self::{
 
 mod logic;
 mod rpc;
+mod webrtc_route;
 
 const GATEWAY_SESSIONS_CONNECT_COUNT: &str = "gateway.sessions.connect.count";
 const GATEWAY_SESSIONS_CONNECT_ERROR: &str = "gateway.sessions.connect.error";
-
-async fn select_node<EMITTER: RpcEmitter + Send + 'static>(emitter: &EMITTER, node_ids: &[u32]) -> Option<u32> {
-    let mut futures = Vec::new();
-
-    for node_id in node_ids {
-        let future = emitter
-            .request::<_, NodeHealthcheckResponse>(
-                MEDIA_SERVER_SERVICE,
-                Some(*node_id),
-                RPC_NODE_HEALTHCHECK,
-                NodeHealthcheckRequest::Webrtc {
-                    max_send_bitrate: 2_000_000,
-                    max_recv_bitrate: 2_000_000,
-                },
-                1000,
-            )
-            .map(move |res| match res {
-                Ok(res) => {
-                    log::info!("on res {:?}", res);
-                    if res.success {
-                        Ok(*node_id)
-                    } else {
-                        Err(())
-                    }
-                }
-                Err(_) => Err(()),
-            });
-        futures.push(future);
-    }
-
-    let first_completed = futures::future::select_ok(futures).await;
-    first_completed.ok().map(|(node_id, _)| node_id)
-}
 
 /// Media Server Webrtc
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct GatewayArgs {}
 
-pub async fn run_gateway_server<C, CR, RPC, REQ, EMITTER>(http_port: u16, _opts: GatewayArgs, _cluster: C, rpc_endpoint: RPC) -> Result<(), &'static str>
+pub async fn run_gateway_server<C, CR, RPC, REQ, EMITTER>(http_port: u16, _opts: GatewayArgs, cluster: C, rpc_endpoint: RPC) -> Result<(), &'static str>
 where
     C: Cluster<CR> + Send + 'static,
     CR: ClusterEndpoint + Send + 'static,
     RPC: RpcEndpoint<REQ, EMITTER>,
-    REQ: RpcRequest + Send + 'static,
-    EMITTER: RpcEmitter + Send + 'static,
+    REQ: RpcRequest + Send + Sync + 'static,
+    EMITTER: RpcEmitter + Send + Sync + 'static,
 {
+    let node_id = cluster.node_id();
     let mut rpc_endpoint = GatewayClusterRpc::new(rpc_endpoint);
     let mut http_server: HttpRpcServer<RpcEvent> = crate::rpc::http::HttpRpcServer::new(http_port);
 
@@ -139,100 +106,16 @@ where
                 req.answer(Ok(gateway_logic.on_ping(timer.now_ms(), req.param())));
             }
             RpcEvent::WhipConnect(req) => {
-                increment_counter!(GATEWAY_SESSIONS_CONNECT_COUNT);
-
                 log::info!("[Gateway] whip connect compressed_sdp: {:?}", req.param().compressed_sdp.as_ref().map(|sdp| sdp.len()));
-                let nodes = gateway_logic.best_nodes(ServiceType::Webrtc, 60, 80, 3);
-                if !nodes.is_empty() {
-                    let rpc_emitter = rpc_emitter.clone();
-                    async_std::task::spawn_local(async move {
-                        log::info!("[Gateway] whip connect => ping nodes {:?}", nodes);
-                        let node_id = select_node(&rpc_emitter, &nodes).await;
-                        if let Some(node_id) = node_id {
-                            log::info!("[Gateway] whip connect with selected node {:?}", node_id);
-                            let res = rpc_emitter
-                                .request::<WhipConnectRequest, WhipConnectResponse>(MEDIA_SERVER_SERVICE, Some(node_id), RPC_WHIP_CONNECT, req.param().clone(), 5000)
-                                .await;
-                            log::info!("[Gateway] whip connect res from media-server {:?}", res.as_ref().map(|_| ()));
-                            if res.is_err() {
-                                increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                            }
-                            req.answer(res.map_err(|_e| "INTERNAL_ERROR"));
-                        } else {
-                            increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                            log::warn!("[Gateway] whep connect but ping nodes {:?} timeout", nodes);
-                            req.answer(Err("NODE_POOL_EMPTY"));
-                        }
-                    });
-                } else {
-                    increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                    log::warn!("[Gateway] whip connect but media-server pool empty");
-                    req.answer(Err("NODE_POOL_EMPTY"));
-                }
+                webrtc_route::route_to_node(rpc_emitter.clone(), timer.clone(), &mut gateway_logic, node_id, ServiceType::Webrtc, RPC_WHIP_CONNECT, req);
             }
             RpcEvent::WhepConnect(req) => {
-                increment_counter!(GATEWAY_SESSIONS_CONNECT_COUNT);
-
                 log::info!("[Gateway] whep connect compressed_sdp: {:?}", req.param().compressed_sdp.as_ref().map(|sdp| sdp.len()));
-                let nodes = gateway_logic.best_nodes(ServiceType::Webrtc, 60, 80, 3);
-                if !nodes.is_empty() {
-                    let rpc_emitter = rpc_emitter.clone();
-                    async_std::task::spawn_local(async move {
-                        log::info!("[Gateway] whep connect => ping nodes {:?}", nodes);
-                        let node_id = select_node(&rpc_emitter, &nodes).await;
-                        if let Some(node_id) = node_id {
-                            log::info!("[Gateway] whep connect with selected node {:?}", node_id);
-                            let res = rpc_emitter
-                                .request::<WhepConnectRequest, WhepConnectResponse>(MEDIA_SERVER_SERVICE, Some(node_id), RPC_WHEP_CONNECT, req.param().clone(), 5000)
-                                .await;
-                            log::info!("[Gateway] whep connect res from media-server {:?}", res.as_ref().map(|_| ()));
-                            if res.is_err() {
-                                increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                            }
-                            req.answer(res.map_err(|_e| "INTERNAL_ERROR"));
-                        } else {
-                            increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                            log::warn!("[Gateway] whep connect but ping nodes {:?} timeout", nodes);
-                            req.answer(Err("NODE_POOL_EMPTY"));
-                        }
-                    });
-                } else {
-                    increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                    log::warn!("[Gateway] whep connect but media-server pool empty");
-                    req.answer(Err("NODE_POOL_EMPTY"));
-                }
+                webrtc_route::route_to_node(rpc_emitter.clone(), timer.clone(), &mut gateway_logic, node_id, ServiceType::Webrtc, RPC_WHEP_CONNECT, req);
             }
             RpcEvent::WebrtcConnect(req) => {
-                increment_counter!(GATEWAY_SESSIONS_CONNECT_COUNT);
-
                 log::info!("[Gateway] webrtc connect compressed_sdp: {:?}", req.param().compressed_sdp.as_ref().map(|sdp| sdp.len()));
-                let nodes = gateway_logic.best_nodes(ServiceType::Webrtc, 60, 80, 3);
-                if !nodes.is_empty() {
-                    let rpc_emitter = rpc_emitter.clone();
-                    async_std::task::spawn_local(async move {
-                        log::info!("[Gateway] webrtc connect => ping nodes {:?}", nodes);
-                        let node_id = select_node(&rpc_emitter, &nodes).await;
-                        if let Some(node_id) = node_id {
-                            log::info!("[Gateway] webrtc connect with selected node {:?}", node_id);
-                            let res = rpc_emitter
-                                .request::<WebrtcConnectRequest, WebrtcConnectResponse>(MEDIA_SERVER_SERVICE, Some(node_id), RPC_WEBRTC_CONNECT, req.param().clone(), 5000)
-                                .await;
-                            log::info!("[Gateway] webrtc connect res from media-server {:?}", res.as_ref().map(|_| ()));
-                            if res.is_err() {
-                                increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                            }
-                            req.answer(res.map_err(|_e| "INTERNAL_ERROR"));
-                        } else {
-                            increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                            log::warn!("[Gateway] webrtc connect but ping nodes {:?} timeout", nodes);
-                            req.answer(Err("NODE_POOL_EMPTY"));
-                        }
-                    });
-                } else {
-                    increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
-                    log::warn!("[Gateway] webrtc connect but media-server pool empty");
-                    req.answer(Err("NODE_POOL_EMPTY"));
-                }
+                webrtc_route::route_to_node(rpc_emitter.clone(), timer.clone(), &mut gateway_logic, node_id, ServiceType::Webrtc, RPC_WEBRTC_CONNECT, req);
             }
             RpcEvent::WebrtcRemoteIce(req) => {
                 if let Some((node_id, _)) = parse_conn_id(&req.param().conn_id) {

--- a/servers/media-server/src/server/gateway.rs
+++ b/servers/media-server/src/server/gateway.rs
@@ -107,15 +107,51 @@ where
             }
             RpcEvent::WhipConnect(req) => {
                 log::info!("[Gateway] whip connect compressed_sdp: {:?}", req.param().compressed_sdp.as_ref().map(|sdp| sdp.len()));
-                webrtc_route::route_to_node(rpc_emitter.clone(), timer.clone(), &mut gateway_logic, node_id, ServiceType::Webrtc, RPC_WHIP_CONNECT, req);
+                webrtc_route::route_to_node(
+                    rpc_emitter.clone(),
+                    timer.clone(),
+                    &mut gateway_logic,
+                    node_id,
+                    ServiceType::Webrtc,
+                    RPC_WHIP_CONNECT,
+                    &req.param().ip_addr.clone(),
+                    &None,
+                    &req.param().user_agent.clone(),
+                    req.param().session_uuid,
+                    req,
+                );
             }
             RpcEvent::WhepConnect(req) => {
                 log::info!("[Gateway] whep connect compressed_sdp: {:?}", req.param().compressed_sdp.as_ref().map(|sdp| sdp.len()));
-                webrtc_route::route_to_node(rpc_emitter.clone(), timer.clone(), &mut gateway_logic, node_id, ServiceType::Webrtc, RPC_WHEP_CONNECT, req);
+                webrtc_route::route_to_node(
+                    rpc_emitter.clone(),
+                    timer.clone(),
+                    &mut gateway_logic,
+                    node_id,
+                    ServiceType::Webrtc,
+                    RPC_WHEP_CONNECT,
+                    &req.param().ip_addr.clone(),
+                    &None,
+                    &req.param().user_agent.clone(),
+                    req.param().session_uuid,
+                    req,
+                );
             }
             RpcEvent::WebrtcConnect(req) => {
                 log::info!("[Gateway] webrtc connect compressed_sdp: {:?}", req.param().compressed_sdp.as_ref().map(|sdp| sdp.len()));
-                webrtc_route::route_to_node(rpc_emitter.clone(), timer.clone(), &mut gateway_logic, node_id, ServiceType::Webrtc, RPC_WEBRTC_CONNECT, req);
+                webrtc_route::route_to_node(
+                    rpc_emitter.clone(),
+                    timer.clone(),
+                    &mut gateway_logic,
+                    node_id,
+                    ServiceType::Webrtc,
+                    RPC_WEBRTC_CONNECT,
+                    &req.param().ip_addr.clone().expect(""),
+                    &req.param().version.clone(),
+                    &req.param().user_agent.clone().expect(""),
+                    req.param().session_uuid.expect(""),
+                    req,
+                );
             }
             RpcEvent::WebrtcRemoteIce(req) => {
                 if let Some((node_id, _)) = parse_conn_id(&req.param().conn_id) {

--- a/servers/media-server/src/server/gateway/rpc.rs
+++ b/servers/media-server/src/server/gateway/rpc.rs
@@ -6,9 +6,9 @@ pub mod http;
 
 pub enum RpcEvent {
     NodePing(Box<dyn RpcReqRes<NodePing, NodePong>>),
-    WhipConnect(Box<dyn RpcReqRes<WhipConnectRequest, WhipConnectResponse>>),
-    WhepConnect(Box<dyn RpcReqRes<WhepConnectRequest, WhepConnectResponse>>),
-    WebrtcConnect(Box<dyn RpcReqRes<WebrtcConnectRequest, WebrtcConnectResponse>>),
+    WhipConnect(Box<dyn RpcReqRes<WhipConnectRequest, WhipConnectResponse> + Sync>),
+    WhepConnect(Box<dyn RpcReqRes<WhepConnectRequest, WhepConnectResponse> + Sync>),
+    WebrtcConnect(Box<dyn RpcReqRes<WebrtcConnectRequest, WebrtcConnectResponse> + Sync>),
     WebrtcRemoteIce(Box<dyn RpcReqRes<WebrtcRemoteIceRequest, WebrtcRemoteIceResponse>>),
     WebrtcSdpPatch(Box<dyn RpcReqRes<WebrtcPatchRequest, WebrtcPatchResponse>>),
     MediaEndpointClose(Box<dyn RpcReqRes<MediaEndpointCloseRequest, MediaEndpointCloseResponse>>),

--- a/servers/media-server/src/server/gateway/rpc/http.rs
+++ b/servers/media-server/src/server/gateway/rpc/http.rs
@@ -38,7 +38,10 @@ impl GatewayHttpApis {
         let string_zip = StringCompression::default();
         log::info!("[HttpApis] create whip endpoint with sdp {}", body.0);
         let (req, rx) = RpcReqResHttp::<WhipConnectRequest, WhipConnectResponse>::new(WhipConnectRequest {
-            token: "token".to_string(),
+            session_uuid: 0,                      //TODO
+            ip_addr: "127.0.0.1".to_string(),     //TODO
+            user_agent: "user_agent".to_string(), //TODO
+            token: "token".to_string(),           //TODO
             sdp: None,
             compressed_sdp: Some(string_zip.compress(&body.0)),
         });
@@ -107,7 +110,10 @@ impl GatewayHttpApis {
         let string_zip = StringCompression::default();
         log::info!("[HttpApis] create whep endpoint with sdp {}", body.0);
         let (req, rx) = RpcReqResHttp::<WhepConnectRequest, WhepConnectResponse>::new(WhepConnectRequest {
-            token: "token".to_string(),
+            session_uuid: 0,                      //TODO
+            ip_addr: "127.0.0.1".to_string(),     //TODO
+            user_agent: "user_agent".to_string(), //TODO
+            token: "token".to_string(),           //TODO
             sdp: None,
             compressed_sdp: Some(string_zip.compress(&body.0)),
         });
@@ -178,6 +184,10 @@ impl GatewayHttpApis {
         if let Some(sdp) = body.0.sdp.take() {
             body.0.compressed_sdp = Some(string_zip.compress(&sdp));
         }
+        body.0.session_uuid = Some(0); //TODO
+        body.0.ip_addr = Some("127.0.0.1".to_string()); //TODO
+        body.0.user_agent = Some("user_agent".to_string()); //TODO
+
         let (req, rx) = RpcReqResHttp::<WebrtcConnectRequest, WebrtcConnectResponse>::new(body.0);
         ctx.0
             .send(RpcEvent::WebrtcConnect(Box::new(req)))

--- a/servers/media-server/src/server/gateway/webrtc_route.rs
+++ b/servers/media-server/src/server/gateway/webrtc_route.rs
@@ -1,0 +1,151 @@
+use std::sync::Arc;
+
+use cluster::{
+    implement::NodeId,
+    rpc::{
+        connector::{MediaEndpointEvent, MediaEndpointLogRequest, MediaEndpointLogResponse},
+        gateway::{NodeHealthcheckRequest, NodeHealthcheckResponse},
+        RpcEmitter, RpcReqRes, RPC_MEDIA_ENDPOINT_LOG, RPC_NODE_HEALTHCHECK,
+    },
+    CONNECTOR_SERVICE, MEDIA_SERVER_SERVICE,
+};
+use futures::FutureExt as _;
+use media_utils::{ErrorDebugger, Timer};
+use metrics::increment_counter;
+
+use crate::server::gateway::{GATEWAY_SESSIONS_CONNECT_COUNT, GATEWAY_SESSIONS_CONNECT_ERROR};
+
+use super::logic::{GatewayLogic, ServiceType};
+
+async fn select_node<EMITTER: RpcEmitter + Send + 'static>(emitter: &EMITTER, node_ids: &[u32]) -> Option<u32> {
+    let mut futures = Vec::new();
+
+    for node_id in node_ids {
+        let future = emitter
+            .request::<_, NodeHealthcheckResponse>(
+                MEDIA_SERVER_SERVICE,
+                Some(*node_id),
+                RPC_NODE_HEALTHCHECK,
+                NodeHealthcheckRequest::Webrtc {
+                    max_send_bitrate: 2_000_000,
+                    max_recv_bitrate: 2_000_000,
+                },
+                1000,
+            )
+            .map(move |res| match res {
+                Ok(res) => {
+                    log::info!("on res {:?}", res);
+                    if res.success {
+                        Ok(*node_id)
+                    } else {
+                        Err(())
+                    }
+                }
+                Err(_) => Err(()),
+            });
+        futures.push(future);
+    }
+
+    let first_completed = futures::future::select_ok(futures).await;
+    first_completed.ok().map(|(node_id, _)| node_id)
+}
+
+// TODO running in queue and retry if failed. It should retry when connector service not accept
+fn emit_endpoint_event<EMITTER: RpcEmitter + Send + 'static>(emitter: &EMITTER, timer: &Arc<dyn Timer>, session_uuid: u64, event: MediaEndpointEvent) {
+    let emitter = emitter.clone();
+    let ts = timer.now_ms();
+    async_std::task::spawn_local(async move {
+        emitter
+            .request::<_, MediaEndpointLogResponse>(
+                CONNECTOR_SERVICE,
+                None,
+                RPC_MEDIA_ENDPOINT_LOG,
+                MediaEndpointLogRequest::SessionEvent {
+                    ip: "127.0.0.1".to_string(), //TODO get real ip
+                    location: None,
+                    version: None,
+                    token: vec![],
+                    ts,
+                    session_uuid,
+                    event,
+                },
+                1000,
+            )
+            .await
+            .log_error("Should ok");
+    });
+}
+
+pub fn route_to_node<EMITTER, Req, Res>(
+    emitter: EMITTER,
+    timer: Arc<dyn Timer>,
+    gateway_logic: &mut GatewayLogic,
+    gateway_node_id: NodeId,
+    service: ServiceType,
+    cmd: &'static str,
+    req: Box<dyn RpcReqRes<Req, Res> + Sync>,
+) where
+    EMITTER: RpcEmitter + Send + Sync + 'static,
+    Req: Into<Vec<u8>> + Send + Sync + Clone + 'static,
+    Res: for<'a> TryFrom<&'a [u8]> + Send + 'static,
+{
+    increment_counter!(GATEWAY_SESSIONS_CONNECT_COUNT);
+    let started_ms = timer.now_ms();
+    let session_uuid = 0; //TODO
+    let event = MediaEndpointEvent::Routing {
+        user_agent: "TODO".to_string(),
+        gateway_node_id,
+    };
+    emit_endpoint_event(&emitter, &timer, session_uuid, event);
+
+    let nodes = gateway_logic.best_nodes(service, 60, 80, 3);
+    if !nodes.is_empty() {
+        let rpc_emitter = emitter.clone();
+        async_std::task::spawn(async move {
+            log::info!("[Gateway] connect => ping nodes {:?}", nodes);
+            let node_id = select_node(&rpc_emitter, &nodes).await;
+            if let Some(node_id) = node_id {
+                log::info!("[Gateway] connect with selected node {:?}", node_id);
+                let res = rpc_emitter.request::<Req, Res>(MEDIA_SERVER_SERVICE, Some(node_id), cmd, req.param().clone(), 5000).await;
+                log::info!("[Gateway] webrtc connect res from media-server {:?}", res.as_ref().map(|_| ()));
+                let event = if res.is_err() {
+                    increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
+                    MediaEndpointEvent::RoutingError {
+                        reason: "NODE_ANSWER_ERROR".to_string(),
+                        gateway_node_id,
+                        media_node_ids: vec![node_id],
+                    }
+                } else {
+                    MediaEndpointEvent::Routed {
+                        media_node_id: node_id,
+                        after_ms: (timer.now_ms() - started_ms) as u32,
+                    }
+                };
+
+                emit_endpoint_event(&emitter, &timer, session_uuid, event);
+                req.answer(res.map_err(|_e| "NODE_ANSWER_ERROR"));
+            } else {
+                log::warn!("[Gateway] webrtc connect but ping nodes {:?} timeout", nodes);
+                increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
+                let event = MediaEndpointEvent::RoutingError {
+                    reason: "NODE_PING_TIMEOUT".to_string(),
+                    gateway_node_id,
+                    media_node_ids: nodes,
+                };
+                emit_endpoint_event(&emitter, &timer, session_uuid, event);
+                req.answer(Err("NODE_PING_TIMEOUT"));
+            }
+        });
+    } else {
+        increment_counter!(GATEWAY_SESSIONS_CONNECT_ERROR);
+        let event = MediaEndpointEvent::RoutingError {
+            reason: "NODE_POOL_EMPTY".to_string(),
+            gateway_node_id,
+            media_node_ids: vec![],
+        };
+        emit_endpoint_event(&emitter, &timer, session_uuid, event);
+
+        log::warn!("[Gateway] webrtc connect but media-server pool empty");
+        req.answer(Err("NODE_POOL_EMPTY"));
+    }
+}

--- a/servers/media-server/src/server/rtmp.rs
+++ b/servers/media-server/src/server/rtmp.rs
@@ -164,7 +164,7 @@ where
                 req.answer(Ok(NodeHealthcheckResponse { success: true }));
             }
             RpcEvent::MediaEndpointClose(req) => {
-                if let Some(old_tx) = ctx.close_conn(&req.param().conn_id) {
+                if let Some(old_tx) = ctx.get_conn(&req.param().conn_id) {
                     async_std::task::spawn(async move {
                         let (tx, rx) = async_std::channel::bounded(1);
                         old_tx.send(InternalControl::ForceClose(tx.clone())).await.log_error("need send");

--- a/servers/media-server/src/server/rtmp/session.rs
+++ b/servers/media-server/src/server/rtmp/session.rs
@@ -59,7 +59,7 @@ impl<E: ClusterEndpoint> RtmpSession<E> {
                 Ok(InternalControl::ForceClose(tx)) => {
                     self.endpoint.close().await;
                     tx.send(()).await.log_error("Should send");
-                    None
+                    Some(())
                 }
                 Err(e) => {
                     log::error!("Error on endpoint custom recv: {:?}", e);

--- a/servers/media-server/src/server/webrtc.rs
+++ b/servers/media-server/src/server/webrtc.rs
@@ -347,7 +347,7 @@ where
                 }
             }
             RpcEvent::MediaEndpointClose(req) => {
-                if let Some(old_tx) = ctx.close_conn(&req.param().conn_id) {
+                if let Some(old_tx) = ctx.get_conn(&req.param().conn_id) {
                     async_std::task::spawn(async move {
                         let (tx, rx) = async_std::channel::bounded(1);
                         old_tx.send(InternalControl::ForceClose(tx.clone())).await.log_error("need send");

--- a/servers/media-server/src/server/webrtc/rpc/http.rs
+++ b/servers/media-server/src/server/webrtc/rpc/http.rs
@@ -37,6 +37,9 @@ impl WebrtcHttpApis {
     async fn create_whip(&self, ctx: Data<&Sender<RpcEvent>>, body: ApplicationSdp<String>) -> Result<HttpResponse<ApplicationSdp<String>>> {
         log::info!("[HttpApis] create whip endpoint with sdp {}", body.0);
         let (req, rx) = RpcReqResHttp::<WhipConnectRequest, WhipConnectResponse>::new(WhipConnectRequest {
+            session_uuid: 0,                      //TODO
+            ip_addr: "127.0.0.1".to_string(),     //TODO
+            user_agent: "user_agent".to_string(), //TODO
             token: "token".to_string(),
             sdp: Some(body.0),
             compressed_sdp: None,
@@ -107,6 +110,9 @@ impl WebrtcHttpApis {
     async fn create_whep(&self, ctx: Data<&Sender<RpcEvent>>, body: ApplicationSdp<String>) -> Result<HttpResponse<ApplicationSdp<String>>> {
         log::info!("[HttpApis] create whep endpoint with sdp {}", body.0);
         let (req, rx) = RpcReqResHttp::<WhepConnectRequest, WhepConnectResponse>::new(WhepConnectRequest {
+            session_uuid: 0,                      //TODO
+            ip_addr: "127.0.0.1".to_string(),     //TODO
+            user_agent: "user_agent".to_string(), //TODO
             token: "token".to_string(),
             sdp: Some(body.0),
             compressed_sdp: None,
@@ -174,8 +180,10 @@ impl WebrtcHttpApis {
 
     /// connect webrtc endpoint
     #[oai(path = "/webrtc/connect", method = "post")]
-    async fn create_webrtc(&self, ctx: Data<&Sender<RpcEvent>>, body: Json<WebrtcConnectRequest>) -> Result<Json<Response<WebrtcSdp>>> {
+    async fn create_webrtc(&self, ctx: Data<&Sender<RpcEvent>>, mut body: Json<WebrtcConnectRequest>) -> Result<Json<Response<WebrtcSdp>>> {
         log::info!("[HttpApis] create Webrtc endpoint {}/{}", body.0.room, body.0.peer);
+        body.0.session_uuid = Some(0); //TODO
+
         let (req, rx) = RpcReqResHttp::<WebrtcConnectRequest, WebrtcConnectResponse>::new(body.0);
         ctx.0
             .send(RpcEvent::WebrtcConnect(Box::new(req)))

--- a/servers/media-server/src/server/webrtc/session.rs
+++ b/servers/media-server/src/server/webrtc/session.rs
@@ -83,7 +83,7 @@ impl<E: ClusterEndpoint, L: TransportLifeCycle> WebrtcSession<E, L> {
                 Ok(InternalControl::ForceClose(tx)) => {
                     self.endpoint.close().await;
                     tx.send(()).await.log_error("Should send");
-                    None
+                    Some(())
                 }
                 Err(e) => {
                     log::error!("Error on endpoint custom recv: {:?}", e);

--- a/transports/rtmp/src/transport.rs
+++ b/transports/rtmp/src/transport.rs
@@ -146,5 +146,6 @@ impl Transport<(), RmIn, RrIn, RlIn, RmOut, RrOut, RlOut> for RtmpTransport {
 
     async fn close(&mut self) {
         self.socket.close().await.log_error("Should close socket");
+        self.actions.push_back(TransportIncomingEvent::State(TransportStateEvent::Disconnected));
     }
 }

--- a/transports/webrtc/src/transport.rs
+++ b/transports/webrtc/src/transport.rs
@@ -211,6 +211,13 @@ where
                         log::error!("error on parse ice candidate {:?}", e);
                     }
                 },
+                Str0mAction::Close => {
+                    if let Some(cid) = self.event_convert.channel_id(0) {
+                        log::info!("[TransportWebrtc] close request");
+                        self.rtc.direct_api().close_data_channel(cid);
+                        self.rtc.disconnect();
+                    }
+                }
             }
         }
     }
@@ -333,9 +340,7 @@ where
     }
 
     async fn close(&mut self) {
-        if let Some(cid) = self.event_convert.channel_id(0) {
-            self.rtc.direct_api().close_data_channel(cid);
-        }
+        self.internal.close();
     }
 }
 

--- a/transports/webrtc/src/transport/internal.rs
+++ b/transports/webrtc/src/transport/internal.rs
@@ -66,6 +66,7 @@ pub enum Str0mAction {
     ConfigEgressBitrate { current: u32, desired: u32 },
     LimitIngressBitrate { mid: Mid, max: u32 },
     RemoteIce(String),
+    Close,
 }
 
 pub struct WebrtcTransportInternal<L>
@@ -355,6 +356,11 @@ where
                 Ok(())
             }
         }
+    }
+
+    pub fn close(&mut self) {
+        self.str0m_actions.push_back(Str0mAction::Close);
+        self.endpoint_actions.push_back(Ok(TransportIncomingEvent::State(transport::TransportStateEvent::Disconnected)));
     }
 
     pub fn endpoint_action(&mut self) -> Option<Result<TransportIncomingEvent<EndpointRpcIn, RemoteTrackRpcIn, LocalTrackRpcIn>, TransportError>> {


### PR DESCRIPTION
This PR implement connector server, which is used to intergrate with other system like:

- admin console
- monitoring ..

Main idea is atm0s-media-server itseft don't do anything with hooks, logging. Instead of it will fire events to message queue like Kafka or NATS for easy extending media-server based on user business logic