### PR TITLE
WIP: audio mix-minus

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -8,6 +8,7 @@ changelog_include = [
     "atm0s-media-server-cluster",
     "atm0s-media-server-endpoint",
     "atm0s-media-server-utils", 
+    "atm0s-media-server-mix-minus", 
     "atm0s-media-server-proc-macro", 
     "atm0s-media-server-transport", 
     "atm0s-media-server-transport-webrtc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "atm0s-media-server-audio-mixer"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "atm0s-media-server-cluster"
 version = "0.1.0"
 dependencies = [
@@ -459,6 +467,7 @@ name = "atm0s-media-server-endpoint"
 version = "0.1.0"
 dependencies = [
  "async-std",
+ "atm0s-media-server-audio-mixer",
  "atm0s-media-server-cluster",
  "atm0s-media-server-transport",
  "atm0s-media-server-utils",
@@ -1433,6 +1442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +1945,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -3650,6 +3678,15 @@ dependencies = [
  "redox_syscall",
  "rustix 0.38.25",
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "packages/cluster",
     "packages/endpoint",
     "packages/transport",
+    "packages/audio-mixer",
     "packages/media-utils",
     "transports/webrtc",
     "transports/rtmp",

--- a/packages/audio-mixer/Cargo.toml
+++ b/packages/audio-mixer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "atm0s-media-server-audio-mixer"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Audio Mixer for atm0s-media-server"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log.workspace = true
+
+[dev-dependencies]
+env_logger.workspace = true

--- a/packages/audio-mixer/src/lib.rs
+++ b/packages/audio-mixer/src/lib.rs
@@ -1,0 +1,3 @@
+mod mixer;
+
+pub use mixer::*;

--- a/packages/audio-mixer/src/mixer.rs
+++ b/packages/audio-mixer/src/mixer.rs
@@ -1,0 +1,408 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+    hash::Hash,
+};
+
+const SILENT_LEVEL: i8 = -127;
+const SWITCH_AUDIO_THRESHOLD: i8 = 30;
+/// if no audio pkt received in AUDIO_SLOT_TIMEOUT_MS, set audio level to SILENT_LEVEL
+const AUDIO_SLOT_TIMEOUT_MS: u64 = 1000;
+
+pub struct AudioMixerConfig {
+    pub outputs: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AudioMixerOutput<Pkt, Src> {
+    SlotPinned(Src, usize),
+    SlotUnpinned(Src, usize),
+    OutputSlotSrcChanged(usize, Option<Src>),
+    OutputSlotPkt(usize, Pkt),
+}
+
+enum SourceState {
+    Unpinned { audio_level: i8, last_changed_at: u64 },
+    Pinned { pinned_at: u64, audio_level: i8, slot: usize, last_changed_at: u64 },
+}
+
+impl SourceState {
+    fn audio_level(&self) -> i8 {
+        match self {
+            SourceState::Unpinned { audio_level, .. } => *audio_level,
+            SourceState::Pinned { audio_level, .. } => *audio_level,
+        }
+    }
+
+    fn slot(&self) -> Option<usize> {
+        match self {
+            SourceState::Unpinned { .. } => None,
+            SourceState::Pinned { slot, .. } => Some(*slot),
+        }
+    }
+
+    fn set_audio_level(&mut self, now_ms: u64, audio_level: i8) {
+        match self {
+            SourceState::Unpinned {
+                audio_level: level, last_changed_at, ..
+            } => {
+                *level = audio_level;
+                *last_changed_at = now_ms;
+            }
+            SourceState::Pinned {
+                audio_level: level, last_changed_at, ..
+            } => {
+                *level = audio_level;
+                *last_changed_at = now_ms;
+            }
+        }
+    }
+
+    fn last_changed_at(&self) -> u64 {
+        match self {
+            SourceState::Unpinned { last_changed_at, .. } => *last_changed_at,
+            SourceState::Pinned { last_changed_at, .. } => *last_changed_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum OutputSlotState<Src: Clone> {
+    Empty,
+    Pinned { pinned_at: u64, audio_level: i8, source: Src, last_changed_at: u64 },
+}
+
+impl<Src: Clone> OutputSlotState<Src> {
+    pub fn audio_level(&self) -> Option<i8> {
+        match self {
+            OutputSlotState::Empty => None,
+            OutputSlotState::Pinned { audio_level, .. } => Some(*audio_level),
+        }
+    }
+}
+
+/// Implement lightweight audio mixer with mix-minus feature
+/// We will select n highest audio-level tracks
+pub struct AudioMixer<Pkt: Clone, Src: Debug + Clone + Eq + Hash> {
+    extractor: Box<dyn (Fn(&Pkt) -> Option<i8>) + Send + Sync>,
+    sources: HashMap<Src, SourceState>,
+    output_slots: Vec<OutputSlotState<Src>>,
+    actions: VecDeque<AudioMixerOutput<Pkt, Src>>,
+}
+
+impl<Pkt: Clone, Src: Debug + Clone + Eq + Hash> AudioMixer<Pkt, Src> {
+    pub fn new(extractor: Box<dyn (Fn(&Pkt) -> Option<i8>) + Send + Sync>, config: AudioMixerConfig) -> Self {
+        log::info!("[AudioMixer] create new with {} outputs", config.outputs);
+
+        Self {
+            extractor,
+            sources: HashMap::new(),
+            output_slots: vec![OutputSlotState::Empty; config.outputs],
+            actions: VecDeque::new(),
+        }
+    }
+
+    pub fn on_tick(&mut self, now_ms: u64) {
+        for (src, state) in &mut self.sources {
+            if state.last_changed_at() + AUDIO_SLOT_TIMEOUT_MS <= now_ms {
+                log::debug!("[AudioMixer] set source {:?} audio level to SILENT_LEVEL after timeout", src);
+                state.set_audio_level(now_ms, SILENT_LEVEL);
+                if let Some(slot) = state.slot() {
+                    if let OutputSlotState::Pinned { audio_level, last_changed_at, .. } = &mut self.output_slots[slot] {
+                        *audio_level = SILENT_LEVEL;
+                        *last_changed_at = now_ms;
+                    }
+                }
+            }
+        }
+    }
+
+    /// add source to mixer
+    /// if mixer slot is not full, select a empty slot and pin the source to the slot
+    pub fn add_source(&mut self, now_ms: u64, source: Src) {
+        if self.sources.contains_key(&source) {
+            return;
+        }
+        if let Some(slot) = self.find_empty_slot() {
+            log::info!("[AudioMixer] add source {:?} to slot {}", source, slot);
+            self.output_slots[slot] = OutputSlotState::Pinned {
+                pinned_at: now_ms,
+                audio_level: SILENT_LEVEL,
+                source: source.clone(),
+                last_changed_at: now_ms,
+            };
+            self.sources.insert(
+                source.clone(),
+                SourceState::Pinned {
+                    pinned_at: now_ms,
+                    audio_level: SILENT_LEVEL,
+                    slot,
+                    last_changed_at: now_ms,
+                },
+            );
+            self.actions.push_back(AudioMixerOutput::SlotPinned(source.clone(), slot));
+            self.actions.push_back(AudioMixerOutput::OutputSlotSrcChanged(slot, Some(source)));
+        } else {
+            log::info!("[AudioMixer] add source {:?} to mixer but no empty slot", source);
+            self.sources.insert(
+                source,
+                SourceState::Unpinned {
+                    audio_level: SILENT_LEVEL,
+                    last_changed_at: now_ms,
+                },
+            );
+        }
+    }
+
+    /// push pkt to mixer, if audio level is higher than lowest audio level + SWITCH_AUDIO_THRESHOLD, switch the slot to the source
+    pub fn push_pkt(&mut self, now_ms: u64, source: Src, pkt: &Pkt) {
+        let audio_level = (self.extractor)(pkt).unwrap_or(SILENT_LEVEL);
+        if let Some(index) = self.set_source_level(now_ms, source, audio_level) {
+            log::trace!("[AudioMixer] push pkt to slot {}, audio level {}", index, audio_level);
+            self.actions.push_back(AudioMixerOutput::OutputSlotPkt(index, pkt.clone()));
+        }
+    }
+
+    /// remove source from mixer
+    /// if removed source id pinned, find another source to fill the slot
+    pub fn remove_source(&mut self, now_ms: u64, source: Src) {
+        if let Some(SourceState::Pinned {
+            pinned_at: _,
+            audio_level: _,
+            slot,
+            last_changed_at: _,
+        }) = self.sources.remove(&source)
+        {
+            //find another source to fill the slot
+            if let Some((src, state)) = self.highest_unpined_source() {
+                log::info!("[AudioMixer] remove source {:?} from slot {}, fill slot with source {:?}", source, slot, src);
+                *state = SourceState::Pinned {
+                    pinned_at: now_ms,
+                    audio_level: state.audio_level(),
+                    slot,
+                    last_changed_at: now_ms,
+                };
+                self.output_slots[slot] = OutputSlotState::Pinned {
+                    pinned_at: now_ms,
+                    audio_level: state.audio_level(),
+                    source: src.clone(),
+                    last_changed_at: now_ms,
+                };
+                self.actions.push_back(AudioMixerOutput::SlotUnpinned(source, slot));
+                self.actions.push_back(AudioMixerOutput::SlotPinned(src.clone(), slot));
+                self.actions.push_back(AudioMixerOutput::OutputSlotSrcChanged(slot, Some(src)));
+            } else {
+                log::info!("[AudioMixer] remove source {:?} from slot {}, no source to fill slot", source, slot);
+                self.output_slots[slot] = OutputSlotState::Empty;
+                self.actions.push_back(AudioMixerOutput::OutputSlotSrcChanged(slot, None));
+            }
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<AudioMixerOutput<Pkt, Src>> {
+        self.actions.pop_front()
+    }
+
+    fn find_empty_slot(&self) -> Option<usize> {
+        for (i, slot) in self.output_slots.iter().enumerate() {
+            if let OutputSlotState::Empty = slot {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    fn highest_unpined_source(&mut self) -> Option<(Src, &mut SourceState)> {
+        let mut highest: Option<(Src, &mut SourceState)> = None;
+        for (src, state) in self.sources.iter_mut() {
+            if let SourceState::Unpinned { audio_level, .. } = state {
+                if let Some((_, highest_state)) = &mut highest {
+                    if *audio_level > highest_state.audio_level() {
+                        highest = Some((src.clone(), state));
+                    }
+                } else {
+                    highest = Some((src.clone(), state));
+                }
+            }
+        }
+        highest
+    }
+
+    fn lowest_pinned_slot(&self) -> Option<(usize, Src, i8, u64)> {
+        let mut lowest: Option<(usize, Src, i8, u64)> = None;
+        for (i, slot) in self.output_slots.iter().enumerate() {
+            if let OutputSlotState::Pinned {
+                audio_level, source, last_changed_at, ..
+            } = slot
+            {
+                if let Some((_, _, lowest_slot_audio_level, lowest_last_changed_at)) = &mut lowest {
+                    if *audio_level < *lowest_slot_audio_level || (*audio_level == *lowest_slot_audio_level && *last_changed_at < *lowest_last_changed_at) {
+                        lowest = Some((i, source.clone(), *audio_level, *last_changed_at));
+                    }
+                } else {
+                    lowest = Some((i, source.clone(), *audio_level, *last_changed_at));
+                }
+            }
+        }
+        lowest
+    }
+
+    /// set audio level for source, if source is pinned return Some(slot index), else return None
+    /// Each time we compare audio level with lowest pinned audio level,
+    /// if audio level is higher than lowest audio level + SWITCH_AUDIO_THRESHOLD,
+    /// we switch the slot to the source
+    fn set_source_level(&mut self, now_ms: u64, source: Src, level: i8) -> Option<usize> {
+        let state = self.sources.get_mut(&source)?;
+        match state {
+            SourceState::Unpinned { audio_level, last_changed_at, .. } => {
+                *audio_level = level;
+                *last_changed_at = now_ms;
+                if let Some((lowest_index, lowest_source, lowest_audio_level, _lowest_last_changed_at)) = self.lowest_pinned_slot() {
+                    if lowest_source != source && level >= lowest_audio_level + SWITCH_AUDIO_THRESHOLD {
+                        log::info!(
+                            "[AudioMixer] switch slot {} from source {:?} to source {:?} with higher audio_level",
+                            lowest_index,
+                            lowest_source,
+                            source
+                        );
+                        self.sources.insert(
+                            source.clone(),
+                            SourceState::Pinned {
+                                pinned_at: now_ms,
+                                audio_level: level,
+                                slot: lowest_index,
+                                last_changed_at: now_ms,
+                            },
+                        );
+                        self.output_slots[lowest_index] = OutputSlotState::Pinned {
+                            pinned_at: now_ms,
+                            audio_level: level,
+                            source: source.clone(),
+                            last_changed_at: now_ms,
+                        };
+
+                        self.actions.push_back(AudioMixerOutput::SlotUnpinned(lowest_source, lowest_index));
+                        self.actions.push_back(AudioMixerOutput::SlotPinned(source.clone(), lowest_index));
+                        self.actions.push_back(AudioMixerOutput::OutputSlotSrcChanged(lowest_index, Some(source)));
+
+                        Some(lowest_index)
+                    } else {
+                        log::trace!(
+                            "[AudioMixer] set source {:?} audio level to {}, but not higher than lowest audio level {} + SWITCH_AUDIO_THRESHOLD {}",
+                            source,
+                            level,
+                            lowest_audio_level,
+                            SWITCH_AUDIO_THRESHOLD
+                        );
+                        None
+                    }
+                } else {
+                    panic!("should not happen");
+                }
+            }
+            SourceState::Pinned {
+                audio_level, slot, last_changed_at, ..
+            } => {
+                *audio_level = level;
+                *last_changed_at = now_ms;
+                if let OutputSlotState::Pinned { audio_level, last_changed_at, .. } = &mut self.output_slots[*slot] {
+                    *audio_level = level;
+                    *last_changed_at = now_ms;
+                }
+                Some(*slot)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{AudioMixer, AudioMixerConfig};
+
+    #[test]
+    fn auto_pin_unpin_some_first_sources() {
+        let mut mixer = AudioMixer::<Option<i8>, u32>::new(Box::new(|v| *v), AudioMixerConfig { outputs: 2 });
+
+        mixer.add_source(0, 100);
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotPinned(100, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotSrcChanged(0, Some(100))));
+        assert_eq!(mixer.pop(), None);
+
+        mixer.add_source(0, 101);
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotPinned(101, 1)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotSrcChanged(1, Some(101))));
+        assert_eq!(mixer.pop(), None);
+
+        mixer.add_source(0, 102);
+        assert_eq!(mixer.pop(), None);
+
+        //now remove pinned source 100 then mixer must switched free slot to source 102
+        mixer.remove_source(0, 100);
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotUnpinned(100, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotPinned(102, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotSrcChanged(0, Some(102))));
+        assert_eq!(mixer.pop(), None);
+
+        mixer.add_source(0, 100);
+        assert_eq!(mixer.pop(), None);
+    }
+
+    #[test]
+    fn auto_set_silent_after_timeout() {
+        let mut mixer = AudioMixer::<Option<i8>, u32>::new(Box::new(|v| *v), AudioMixerConfig { outputs: 1 });
+
+        mixer.add_source(0, 100);
+        mixer.add_source(0, 101);
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotPinned(100, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotSrcChanged(0, Some(100))));
+        assert_eq!(mixer.pop(), None);
+
+        mixer.push_pkt(100, 100, &Some(10));
+        mixer.push_pkt(100, 101, &Some(10));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotPkt(0, Some(10))));
+        assert_eq!(mixer.pop(), None);
+
+        //will reset audio level to SILENT_LEVEL after AUDIO_SLOT_TIMEOUT_MS
+        mixer.on_tick(100 + super::AUDIO_SLOT_TIMEOUT_MS);
+
+        assert_eq!(mixer.sources.get(&100).expect("").audio_level(), super::SILENT_LEVEL);
+        assert_eq!(mixer.output_slots[0].audio_level(), Some(super::SILENT_LEVEL));
+
+        //now mixer will switch slot to source 101
+        mixer.push_pkt(100 + super::AUDIO_SLOT_TIMEOUT_MS, 101, &Some(6));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotUnpinned(100, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotPinned(101, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotSrcChanged(0, Some(101))));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotPkt(0, Some(6))));
+        assert_eq!(mixer.pop(), None);
+    }
+
+    #[test]
+    fn switch_higher_source() {
+        let mut mixer = AudioMixer::<Option<i8>, u32>::new(Box::new(|v| *v), AudioMixerConfig { outputs: 1 });
+
+        mixer.add_source(0, 100);
+        mixer.add_source(0, 101);
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotPinned(100, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotSrcChanged(0, Some(100))));
+        assert_eq!(mixer.pop(), None);
+
+        let first_level = 10;
+        mixer.push_pkt(100, 100, &Some(first_level));
+        mixer.push_pkt(100, 101, &Some(0));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotPkt(0, Some(first_level))));
+        assert_eq!(mixer.pop(), None);
+
+        //dont switch if dont higher than SWITCH_AUDIO_THRESHOLD
+        mixer.push_pkt(100, 101, &Some(first_level + super::SWITCH_AUDIO_THRESHOLD / 2));
+        assert_eq!(mixer.pop(), None);
+
+        //now mixer will switch slot to source 101
+        mixer.push_pkt(100, 101, &Some(first_level + super::SWITCH_AUDIO_THRESHOLD));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotUnpinned(100, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::SlotPinned(101, 0)));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotSrcChanged(0, Some(101))));
+        assert_eq!(mixer.pop(), Some(super::AudioMixerOutput::OutputSlotPkt(0, Some(first_level + super::SWITCH_AUDIO_THRESHOLD))));
+        assert_eq!(mixer.pop(), None);
+    }
+}

--- a/packages/cluster/src/define/local_track.rs
+++ b/packages/cluster/src/define/local_track.rs
@@ -1,6 +1,6 @@
 use transport::{MediaPacket, RequestKeyframeKind};
 
-use crate::{ClusterPeerId, ClusterTrackName, ClusterTrackStats};
+use crate::{ClusterPeerId, ClusterTrackName, ClusterTrackStats, ClusterTrackUuid};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ClusterLocalTrackOutgoingEvent {
@@ -12,6 +12,6 @@ pub enum ClusterLocalTrackOutgoingEvent {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ClusterLocalTrackIncomingEvent {
-    MediaPacket(MediaPacket),
-    MediaStats(ClusterTrackStats),
+    MediaPacket(ClusterTrackUuid, MediaPacket),
+    MediaStats(ClusterTrackUuid, ClusterTrackStats),
 }

--- a/packages/cluster/src/define/mod.rs
+++ b/packages/cluster/src/define/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 
 mod endpoint;
 mod local_track;
@@ -12,21 +13,38 @@ pub use local_track::*;
 pub use media::*;
 pub use remote_track::*;
 
-pub type ClusterTrackUuid = u64;
 pub type ClusterPeerId = String;
 pub type ClusterTrackName = String;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct ClusterTrackUuid(u32);
+
+impl ClusterTrackUuid {
+    pub fn from_info(room_id: &str, peer_id: &str, track_name: &str) -> Self {
+        let based = format!("{}-{}-{}", room_id, peer_id, track_name);
+        let mut s = DefaultHasher::new();
+        based.hash(&mut s);
+        Self(s.finish() as u32)
+    }
+}
+
+impl Deref for ClusterTrackUuid {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<u32> for ClusterTrackUuid {
+    fn from(v: u32) -> Self {
+        Self(v)
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ClusterEndpointError {
     InternalError,
-}
-
-/// generate for other peer
-pub fn generate_cluster_track_uuid(room_id: &str, peer_id: &str, track_name: &str) -> ClusterTrackUuid {
-    let based = format!("{}-{}-{}", room_id, peer_id, track_name);
-    let mut s = DefaultHasher::new();
-    based.hash(&mut s);
-    s.finish()
 }
 
 pub trait Cluster<C>: Send + Sync

--- a/packages/cluster/src/implement/endpoint.rs
+++ b/packages/cluster/src/implement/endpoint.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    generate_cluster_track_uuid,
     rpc::{connector::MediaEndpointLogResponse, RPC_MEDIA_ENDPOINT_LOG},
     ClusterEndpoint, ClusterEndpointError, ClusterEndpointIncomingEvent, ClusterEndpointOutgoingEvent, ClusterLocalTrackIncomingEvent, ClusterLocalTrackOutgoingEvent, ClusterRemoteTrackIncomingEvent,
-    ClusterRemoteTrackOutgoingEvent, CONNECTOR_SERVICE,
+    ClusterRemoteTrackOutgoingEvent, ClusterTrackUuid, CONNECTOR_SERVICE,
 };
 use async_std::channel::{bounded, Receiver, Sender};
 use atm0s_sdn::{
@@ -175,41 +174,45 @@ impl ClusterEndpoint for ClusterEndpointSdn {
                     Ok(())
                 }
                 ClusterLocalTrackOutgoingEvent::Subscribe(peer_id, track_name) => {
-                    let track_uuid = generate_cluster_track_uuid(&self.room_id, &peer_id, &track_name);
-                    let consumer = self.pubsub_sdk.create_consumer_raw(track_uuid as ChannelUuid, self.data_tx.clone());
-                    log::info!("[Atm0sClusterEndpoint] sub track {peer_id} {track_name} => track_uuid {track_uuid} consumer_id {}", consumer.uuid());
+                    let track_uuid = ClusterTrackUuid::from_info(&self.room_id, &peer_id, &track_name);
+                    let consumer = self.pubsub_sdk.create_consumer_raw(*track_uuid as ChannelUuid, self.data_tx.clone());
+                    log::info!("[Atm0sClusterEndpoint] sub track {peer_id} {track_name} => track_uuid {} consumer_id {}", *track_uuid, consumer.uuid());
                     self.consumer_map.insert(consumer.uuid(), track_id);
                     self.track_sub_map.insert(track_id, consumer);
                     Ok(())
                 }
                 ClusterLocalTrackOutgoingEvent::Unsubscribe(peer_id, track_name) => {
-                    let track_uuid = generate_cluster_track_uuid(&self.room_id, &peer_id, &track_name);
+                    let track_uuid = ClusterTrackUuid::from_info(&self.room_id, &peer_id, &track_name);
                     if let Some(consumer) = self.track_sub_map.remove(&track_id) {
-                        log::info!("[Atm0sClusterEndpoint] unsub track {peer_id} {track_name} => track_uuid {track_uuid} consumer_id {}", consumer.uuid());
+                        log::info!(
+                            "[Atm0sClusterEndpoint] unsub track {peer_id} {track_name} => track_uuid {} consumer_id {}",
+                            *track_uuid,
+                            consumer.uuid()
+                        );
                         self.consumer_map.remove(&consumer.uuid());
                     } else {
-                        log::warn!("[Atm0sClusterEndpoint] unsub track but not found {peer_id} {track_name} => track_uuid {track_uuid}");
+                        log::warn!("[Atm0sClusterEndpoint] unsub track but not found {peer_id} {track_name} => track_uuid {}", *track_uuid);
                     }
                     Ok(())
                 }
             },
             ClusterEndpointOutgoingEvent::RemoteTrackEvent(track_id, track_uuid, event) => {
-                let channel_uuid = track_uuid as ChannelUuid;
+                let channel_uuid = *track_uuid;
                 match event {
                     ClusterRemoteTrackOutgoingEvent::TrackAdded(track_name, track_meta) => {
                         if !self.track_pub.contains_key(&channel_uuid) {
                             let (sub_key, value) = to_room_value(&self.peer_id, &track_name, track_meta);
                             self.track_pub
-                                .insert(channel_uuid, (track_id, self.pubsub_sdk.create_publisher_raw(track_uuid as ChannelUuid, self.data_fb_tx.clone())));
+                                .insert(channel_uuid, (track_id, self.pubsub_sdk.create_publisher_raw(channel_uuid, self.data_fb_tx.clone())));
 
                             //set in room hashmap
                             self.kv_sdk.hset(self.room_key, sub_key, value.clone(), Some(10000));
                             //set in peer hashmap
                             self.kv_sdk.hset(self.peer_key(&self.peer_id), sub_key, value, Some(10000));
-                            log::info!("[Atm0sClusterEndpoint] add track {} {track_name} => track_uuid {track_uuid} track_id {track_id}", self.peer_id);
+                            log::info!("[Atm0sClusterEndpoint] add track {} {track_name} => track_uuid {channel_uuid} track_id {track_id}", self.peer_id);
                         } else {
                             log::warn!(
-                                "[Atm0sClusterEndpoint] add track but already exist {} {track_name} => track_uuid {track_uuid} track_id {track_id}",
+                                "[Atm0sClusterEndpoint] add track but already exist {} {track_name} => track_uuid {channel_uuid} track_id {track_id}",
                                 self.peer_id
                             );
                         }
@@ -244,10 +247,10 @@ impl ClusterEndpoint for ClusterEndpointSdn {
 
                             //del in peer hashmap
                             self.kv_sdk.hdel(self.peer_key(&self.peer_id), sub_key);
-                            log::info!("[Atm0sClusterEndpoint] delete track {} {track_name} => track_uuid {track_uuid} track_id {track_id}", self.peer_id);
+                            log::info!("[Atm0sClusterEndpoint] delete track {} {track_name} => track_uuid {channel_uuid} track_id {track_id}", self.peer_id);
                         } else {
                             log::warn!(
-                                "[Atm0sClusterEndpoint] delete track but not found {} {track_name} => track_uuid {track_uuid} track_id {track_id}",
+                                "[Atm0sClusterEndpoint] delete track but not found {} {track_name} => track_uuid {channel_uuid} track_id {track_id}",
                                 self.peer_id
                             );
                         }
@@ -322,15 +325,15 @@ impl ClusterEndpoint for ClusterEndpointSdn {
                     }
                 },
                 event = self.data_rx.recv().fuse() => match event {
-                    Ok((sub_id, _node_id, _channel_uuid, data)) => {
+                    Ok((sub_id, _node_id, channel_uuid, data)) => {
                         if let Some(track_id) = self.consumer_map.get(&sub_id) {
                             log::trace!("[Atm0sClusterEndpoint] recv track data {sub_id} => {track_id}");
                             match TrackData::try_from(data) {
                                 Ok(TrackData::Media(media_packet)) => {
-                                    return Ok(ClusterEndpointIncomingEvent::LocalTrackEvent(*track_id, ClusterLocalTrackIncomingEvent::MediaPacket(media_packet)));
+                                    return Ok(ClusterEndpointIncomingEvent::LocalTrackEvent(*track_id, ClusterLocalTrackIncomingEvent::MediaPacket(channel_uuid.into(), media_packet)));
                                 },
                                 Ok(TrackData::Stats(stats)) => {
-                                    return Ok(ClusterEndpointIncomingEvent::LocalTrackEvent(*track_id, ClusterLocalTrackIncomingEvent::MediaStats(stats)));
+                                    return Ok(ClusterEndpointIncomingEvent::LocalTrackEvent(*track_id, ClusterLocalTrackIncomingEvent::MediaStats(channel_uuid.into(), stats)));
                                 },
                                 Err(_e) => {
 

--- a/packages/cluster/src/implement/endpoint.rs
+++ b/packages/cluster/src/implement/endpoint.rs
@@ -182,7 +182,7 @@ impl ClusterEndpoint for ClusterEndpointSdn {
                     let consumer = self.pubsub_sdk.create_consumer_raw(*track_uuid as ChannelUuid, self.data_tx.clone());
                     log::info!("[Atm0sClusterEndpoint] sub track {peer_id} {track_name} => track_uuid {} consumer_id {}", *track_uuid, consumer.uuid());
                     self.consumer_map.insert(consumer.uuid(), track_id);
-                    let entry = self.track_sub_map.entry(track_id).or_insert_with(HashMap::new);
+                    let entry = self.track_sub_map.entry(track_id).or_insert_with(Default::default);
                     entry.insert(track_uuid, consumer);
                     Ok(())
                 }

--- a/packages/endpoint/Cargo.toml
+++ b/packages/endpoint/Cargo.toml
@@ -11,6 +11,7 @@ description = "Media Endpoint for atm0s-media-server"
 cluster = { package = "atm0s-media-server-cluster", path = "../cluster", version = "0.1.0" }
 transport = { package = "atm0s-media-server-transport", path = "../transport", version = "0.1.0" }
 media-utils = { package = "atm0s-media-server-utils", path = "../media-utils", version = "0.1.0" }
+audio-mixer = { package = "atm0s-media-server-audio-mixer", path = "../audio-mixer", version = "0.1.0" }
 log = { workspace = true }
 async-std = { workspace = true }
 serde = { workspace = true }

--- a/packages/endpoint/src/endpoint_pre.rs
+++ b/packages/endpoint/src/endpoint_pre.rs
@@ -1,4 +1,4 @@
-use cluster::{ClusterEndpoint, EndpointSubscribeScope};
+use cluster::{ClusterEndpoint, EndpointSubscribeScope, MixMinusAudioMode};
 use media_utils::ServerError;
 use transport::Transport;
 
@@ -13,15 +13,19 @@ pub struct MediaEndpointPreconditional {
     peer: String,
     subscribe_scope: EndpointSubscribeScope,
     bitrate_type: BitrateLimiterType,
+    mix_minus_mode: MixMinusAudioMode,
+    mix_minus_size: usize,
 }
 
 impl MediaEndpointPreconditional {
-    pub fn new(room: &str, peer: &str, subscribe_scope: EndpointSubscribeScope, bitrate_type: BitrateLimiterType) -> Self {
+    pub fn new(room: &str, peer: &str, subscribe_scope: EndpointSubscribeScope, bitrate_type: BitrateLimiterType, mix_minus_mode: MixMinusAudioMode, mix_minus_size: usize) -> Self {
         Self {
             room: room.into(),
             peer: peer.into(),
             subscribe_scope,
             bitrate_type,
+            mix_minus_mode,
+            mix_minus_size,
         }
     }
 
@@ -34,6 +38,8 @@ impl MediaEndpointPreconditional {
         transport: T,
         cluster: C,
     ) -> MediaEndpoint<T, E, C> {
-        MediaEndpoint::new(transport, cluster, &self.room, &self.peer, self.subscribe_scope, self.bitrate_type)
+        MediaEndpoint::new(
+            transport, cluster, &self.room, &self.peer, self.subscribe_scope, self.bitrate_type, self.mix_minus_mode, self.mix_minus_size,
+        )
     }
 }

--- a/packages/endpoint/src/endpoint_wrap/internal.rs
+++ b/packages/endpoint/src/endpoint_wrap/internal.rs
@@ -450,10 +450,10 @@ impl MediaEndpointInternal {
         has_event
     }
 
-    fn pop_middlewares_action(&mut self, _now_ms: u64) -> bool {
+    fn pop_middlewares_action(&mut self, now_ms: u64) -> bool {
         let mut has_event = false;
         for middleware in self.middlewares.iter_mut() {
-            while let Some(action) = middleware.pop_action() {
+            while let Some(action) = middleware.pop_action(now_ms) {
                 has_event = true;
                 match action {
                     MediaEndpointMiddlewareOutput::Endpoint(event) => {

--- a/packages/endpoint/src/endpoint_wrap/internal.rs
+++ b/packages/endpoint/src/endpoint_wrap/internal.rs
@@ -499,7 +499,7 @@ impl Drop for MediaEndpointInternal {
 
 #[cfg(test)]
 mod tests {
-    use cluster::{generate_cluster_track_uuid, ClusterEndpointIncomingEvent, ClusterEndpointOutgoingEvent, ClusterLocalTrackOutgoingEvent, ClusterRemoteTrackOutgoingEvent, ClusterTrackMeta};
+    use cluster::{ClusterEndpointIncomingEvent, ClusterEndpointOutgoingEvent, ClusterLocalTrackOutgoingEvent, ClusterRemoteTrackOutgoingEvent, ClusterTrackMeta, ClusterTrackUuid};
     use transport::{
         LocalTrackIncomingEvent, LocalTrackOutgoingEvent, MediaPacket, RemoteTrackIncomingEvent, RequestKeyframeKind, TrackMeta, TransportIncomingEvent, TransportOutgoingEvent, TransportStateEvent,
     };
@@ -516,7 +516,7 @@ mod tests {
     fn should_fire_cluster_when_remote_track_added_then_close() {
         let mut endpoint = MediaEndpointInternal::new("room1", "peer1", BitrateLimiterType::DynamicWithConsumers, vec![]);
 
-        let cluster_track_uuid = generate_cluster_track_uuid("room1", "peer1", "audio_main");
+        let cluster_track_uuid = ClusterTrackUuid::from_info("room1", "peer1", "audio_main");
         endpoint.on_transport(0, TransportIncomingEvent::RemoteTrackAdded("audio_main".to_string(), 100, TrackMeta::new_audio(None)));
 
         assert_eq!(endpoint.remote_tracks.len(), 1);
@@ -560,7 +560,7 @@ mod tests {
     fn should_fire_cluster_when_remote_track_added_then_removed() {
         let mut endpoint = MediaEndpointInternal::new("room1", "peer1", BitrateLimiterType::DynamicWithConsumers, vec![]);
 
-        let cluster_track_uuid = generate_cluster_track_uuid("room1", "peer1", "audio_main");
+        let cluster_track_uuid = ClusterTrackUuid::from_info("room1", "peer1", "audio_main");
         endpoint.on_transport(0, TransportIncomingEvent::RemoteTrackAdded("audio_main".to_string(), 100, TrackMeta::new_audio(None)));
 
         assert_eq!(endpoint.remote_tracks.len(), 1);

--- a/packages/endpoint/src/endpoint_wrap/internal/local_track.rs
+++ b/packages/endpoint/src/endpoint_wrap/internal/local_track.rs
@@ -92,7 +92,7 @@ impl LocalTrack {
 
     pub fn on_cluster_event(&mut self, now_ms: u64, event: ClusterLocalTrackIncomingEvent) {
         match event {
-            ClusterLocalTrackIncomingEvent::MediaPacket(pkt) => {
+            ClusterLocalTrackIncomingEvent::MediaPacket(_track_uuid, pkt) => {
                 if let Some(stats) = self.source_stats_generator.on_pkt(&pkt) {
                     log::info!("[LocalTrack {}] auto generate stats {:?}", self.track_name, stats);
                     self.out_actions.push_back(LocalTrackOutput::Internal(LocalTrackInternalOutputEvent::SourceStats(stats)));
@@ -103,7 +103,7 @@ impl LocalTrack {
                     self.out_actions.push_back(LocalTrackOutput::Transport(LocalTrackOutgoingEvent::MediaPacket(pkt)));
                 }
             }
-            ClusterLocalTrackIncomingEvent::MediaStats(stats) => {
+            ClusterLocalTrackIncomingEvent::MediaStats(_track_uuid, stats) => {
                 log::info!("[LocalTrack {}] stats {:?}", self.track_name, stats);
                 self.out_actions.push_back(LocalTrackOutput::Internal(LocalTrackInternalOutputEvent::SourceStats(stats)));
                 self.source_stats_generator.arrived_stats();
@@ -199,7 +199,7 @@ mod tests {
         let mut track = LocalTrack::new("room1", "peer1", 100, "audio_main", TrackMeta::new_audio(None));
 
         let pkt = MediaPacket::simple_audio(1, 0, vec![1, 2, 3]);
-        track.on_cluster_event(0, ClusterLocalTrackIncomingEvent::MediaPacket(pkt.clone()));
+        track.on_cluster_event(0, ClusterLocalTrackIncomingEvent::MediaPacket(0.into(), pkt.clone()));
         assert_eq!(track.pop_action(), Some(LocalTrackOutput::Transport(LocalTrackOutgoingEvent::MediaPacket(pkt))));
     }
 

--- a/packages/endpoint/src/endpoint_wrap/internal/remote_track.rs
+++ b/packages/endpoint/src/endpoint_wrap/internal/remote_track.rs
@@ -1,6 +1,4 @@
-use cluster::{
-    generate_cluster_track_uuid, ClusterRemoteTrackIncomingEvent, ClusterRemoteTrackOutgoingEvent, ClusterTrackMeta, ClusterTrackScalingType, ClusterTrackStats, ClusterTrackStatus, ClusterTrackUuid,
-};
+use cluster::{ClusterRemoteTrackIncomingEvent, ClusterRemoteTrackOutgoingEvent, ClusterTrackMeta, ClusterTrackScalingType, ClusterTrackStats, ClusterTrackStatus, ClusterTrackUuid};
 use std::collections::VecDeque;
 use transport::{RemoteTrackIncomingEvent, RemoteTrackOutgoingEvent, TrackId, TrackMeta};
 
@@ -36,7 +34,7 @@ pub struct RemoteTrack {
 impl RemoteTrack {
     pub fn new(room_id: &str, peer_id: &str, track_id: TrackId, track_name: &str, track_meta: TrackMeta) -> Self {
         Self {
-            cluster_track_uuid: generate_cluster_track_uuid(room_id, peer_id, track_name),
+            cluster_track_uuid: ClusterTrackUuid::from_info(room_id, peer_id, track_name),
             track_id,
             track_name: track_name.into(),
             bitrate_measure: if track_meta.kind.is_video() {

--- a/packages/endpoint/src/middleware.rs
+++ b/packages/endpoint/src/middleware.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 pub mod logger;
+pub mod mix_minus;
 
 pub enum MediaEndpointMiddlewareOutput {
     Endpoint(TransportOutgoingEvent<EndpointRpcOut, RemoteTrackRpcOut, LocalTrackRpcOut>),

--- a/packages/endpoint/src/middleware.rs
+++ b/packages/endpoint/src/middleware.rs
@@ -9,6 +9,7 @@ use crate::{
 pub mod logger;
 pub mod mix_minus;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum MediaEndpointMiddlewareOutput {
     Endpoint(TransportOutgoingEvent<EndpointRpcOut, RemoteTrackRpcOut, LocalTrackRpcOut>),
     Cluster(ClusterEndpointOutgoingEvent),

--- a/packages/endpoint/src/middleware.rs
+++ b/packages/endpoint/src/middleware.rs
@@ -23,5 +23,5 @@ pub trait MediaEndpointMiddleware: Send + Sync {
     fn on_transport_error(&mut self, now_ms: u64, error: &TransportError) -> bool;
     /// return true if event is consumed
     fn on_cluster(&mut self, now_ms: u64, event: &ClusterEndpointIncomingEvent) -> bool;
-    fn pop_action(&mut self) -> Option<MediaEndpointMiddlewareOutput>;
+    fn pop_action(&mut self, now_ms: u64) -> Option<MediaEndpointMiddlewareOutput>;
 }

--- a/packages/endpoint/src/middleware/logger.rs
+++ b/packages/endpoint/src/middleware/logger.rs
@@ -131,7 +131,7 @@ impl MediaEndpointMiddleware for MediaEndpointEventLogger {
         false
     }
 
-    fn pop_action(&mut self) -> Option<crate::MediaEndpointMiddlewareOutput> {
+    fn pop_action(&mut self, _now_ms: u64) -> Option<crate::MediaEndpointMiddlewareOutput> {
         self.outputs.pop_back()
     }
 }

--- a/packages/endpoint/src/middleware/mix_minus.rs
+++ b/packages/endpoint/src/middleware/mix_minus.rs
@@ -1,0 +1,202 @@
+use std::{collections::VecDeque, vec};
+
+use audio_mixer::{AudioMixer, AudioMixerOutput};
+use cluster::{ClusterEndpointIncomingEvent, ClusterEndpointOutgoingEvent, ClusterLocalTrackIncomingEvent, ClusterLocalTrackOutgoingEvent, ClusterTrackUuid, MixMinusAudioMode};
+use transport::{LocalTrackIncomingEvent, LocalTrackOutgoingEvent, MediaKind, MediaPacket, TrackId, TransportError, TransportIncomingEvent, TransportOutgoingEvent};
+
+use crate::{
+    rpc::{LocalTrackRpcIn, LocalTrackRpcOut, RemoteTrackRpcIn, TrackInfo},
+    EndpointRpcIn, EndpointRpcOut, MediaEndpointMiddleware, MediaEndpointMiddlewareOutput, RpcResponse,
+};
+
+const SILENT_LEVEL: i8 = -127;
+
+pub struct MixMinusEndpointMiddleware {
+    virtual_track_id: u16,
+    room: String,
+    name: String,
+    mode: MixMinusAudioMode,
+    mixer: AudioMixer<MediaPacket, ClusterTrackUuid>,
+    output_slots: Vec<Option<TrackId>>,
+    outputs: VecDeque<MediaEndpointMiddlewareOutput>,
+}
+
+impl MixMinusEndpointMiddleware {
+    pub fn new(room: &str, name: &str, mode: MixMinusAudioMode, virtual_track_id: u16, outputs: usize) -> Self {
+        Self {
+            virtual_track_id,
+            room: room.to_string(),
+            name: name.to_string(),
+            mode,
+            mixer: AudioMixer::new(Box::new(|pkt| pkt.ext_vals.audio_level), audio_mixer::AudioMixerConfig { outputs }),
+            output_slots: vec![None; outputs],
+            outputs: VecDeque::new(),
+        }
+    }
+}
+
+impl MediaEndpointMiddleware for MixMinusEndpointMiddleware {
+    fn on_start(&mut self, _now_ms: u64) {
+        for i in 0..self.output_slots.len() {
+            self.outputs
+                .push_back(MediaEndpointMiddlewareOutput::Endpoint(TransportOutgoingEvent::Rpc(EndpointRpcOut::TrackAdded(TrackInfo {
+                    peer_hash: 0,
+                    peer: "".to_string(),
+                    kind: MediaKind::Audio,
+                    track: format!("mix_minus_{}_{}", self.name, i),
+                    state: None,
+                }))));
+        }
+    }
+
+    fn on_tick(&mut self, now_ms: u64) {
+        self.mixer.on_tick(now_ms);
+    }
+
+    fn on_transport(&mut self, now_ms: u64, event: &TransportIncomingEvent<EndpointRpcIn, RemoteTrackRpcIn, LocalTrackRpcIn>) -> bool {
+        match event {
+            TransportIncomingEvent::LocalTrackEvent(track_id, LocalTrackIncomingEvent::Rpc(LocalTrackRpcIn::Switch(req))) => {
+                if req.data.remote.peer.is_empty() && req.data.remote.stream.starts_with(&format!("mix_minus_{}_", self.name)) {
+                    //extract slot_index from mix_minus_{name}_slot_{index}
+                    let res = if let Some(Ok(slot_index)) = req.data.remote.stream.split('_').last().map(|i| i.parse::<usize>()) {
+                        if let Some(slot) = self.output_slots.get_mut(slot_index) {
+                            slot.replace(*track_id);
+                            RpcResponse::success(req.req_id, true)
+                        } else {
+                            RpcResponse::error(req.req_id)
+                        }
+                    } else {
+                        RpcResponse::error(req.req_id)
+                    };
+
+                    self.outputs.push_back(MediaEndpointMiddlewareOutput::Endpoint(TransportOutgoingEvent::LocalTrackEvent(
+                        *track_id,
+                        LocalTrackOutgoingEvent::Rpc(LocalTrackRpcOut::SwitchRes(res)),
+                    )));
+
+                    true
+                } else {
+                    false
+                }
+            }
+            TransportIncomingEvent::LocalTrackEvent(track_id, LocalTrackIncomingEvent::Rpc(LocalTrackRpcIn::Disconnect(req))) => {
+                let track_id = *track_id;
+                if let Some(found_slot) = self.output_slots.iter_mut().find(move |slot| Some(track_id).eq(slot)) {
+                    *found_slot = None;
+                    self.outputs.push_back(MediaEndpointMiddlewareOutput::Endpoint(TransportOutgoingEvent::LocalTrackEvent(
+                        track_id,
+                        LocalTrackOutgoingEvent::Rpc(LocalTrackRpcOut::DisconnectRes(RpcResponse::success(req.req_id, true))),
+                    )));
+                    true
+                } else {
+                    false
+                }
+            }
+            TransportIncomingEvent::Rpc(EndpointRpcIn::MixMinusSourceAdd(req)) => {
+                if matches!(self.mode, MixMinusAudioMode::ManualAudioStreams) && req.data.id == self.name {
+                    let remote_peer = req.data.remote.peer.clone();
+                    let remote_stream = req.data.remote.stream.clone();
+                    self.mixer.add_source(now_ms, ClusterTrackUuid::from_info(&self.room, &remote_peer, &remote_stream));
+                    self.outputs
+                        .push_back(MediaEndpointMiddlewareOutput::Endpoint(TransportOutgoingEvent::Rpc(EndpointRpcOut::MixMinusSourceAddRes(
+                            RpcResponse::success(req.req_id, true),
+                        ))));
+                    self.outputs.push_back(MediaEndpointMiddlewareOutput::Cluster(ClusterEndpointOutgoingEvent::LocalTrackEvent(
+                        self.virtual_track_id,
+                        ClusterLocalTrackOutgoingEvent::Subscribe(remote_peer, remote_stream),
+                    )));
+                    true
+                } else {
+                    false
+                }
+            }
+            TransportIncomingEvent::Rpc(EndpointRpcIn::MixMinusSourceRemove(req)) => {
+                if matches!(self.mode, MixMinusAudioMode::ManualAudioStreams) && req.data.id == self.name {
+                    let remote_peer = req.data.remote.peer.clone();
+                    let remote_stream = req.data.remote.stream.clone();
+                    self.mixer.remove_source(now_ms, ClusterTrackUuid::from_info(&self.room, &remote_peer, &remote_stream));
+                    self.outputs
+                        .push_back(MediaEndpointMiddlewareOutput::Endpoint(TransportOutgoingEvent::Rpc(EndpointRpcOut::MixMinusSourceRemoveRes(
+                            RpcResponse::success(req.req_id, true),
+                        ))));
+                    self.outputs.push_back(MediaEndpointMiddlewareOutput::Cluster(ClusterEndpointOutgoingEvent::LocalTrackEvent(
+                        self.virtual_track_id,
+                        ClusterLocalTrackOutgoingEvent::Unsubscribe(remote_peer, remote_stream),
+                    )));
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn on_transport_error(&mut self, _now_ms: u64, _error: &TransportError) -> bool {
+        false
+    }
+
+    fn on_cluster(&mut self, now_ms: u64, event: &ClusterEndpointIncomingEvent) -> bool {
+        match event {
+            ClusterEndpointIncomingEvent::PeerTrackAdded(peer, track, _meta) => {
+                if matches!(self.mode, MixMinusAudioMode::AllAudioStreams) {
+                    self.mixer.add_source(now_ms, ClusterTrackUuid::from_info(&self.room, peer, track));
+                    self.outputs.push_back(MediaEndpointMiddlewareOutput::Cluster(ClusterEndpointOutgoingEvent::LocalTrackEvent(
+                        self.virtual_track_id,
+                        ClusterLocalTrackOutgoingEvent::Subscribe(peer.clone(), track.clone()),
+                    )));
+                }
+                false
+            }
+            ClusterEndpointIncomingEvent::PeerTrackRemoved(peer, track) => {
+                if matches!(self.mode, MixMinusAudioMode::AllAudioStreams) {
+                    self.mixer.remove_source(now_ms, ClusterTrackUuid::from_info(&self.room, peer, track));
+                    self.outputs.push_back(MediaEndpointMiddlewareOutput::Cluster(ClusterEndpointOutgoingEvent::LocalTrackEvent(
+                        self.virtual_track_id,
+                        ClusterLocalTrackOutgoingEvent::Unsubscribe(peer.clone(), track.clone()),
+                    )));
+                }
+                false
+            }
+            ClusterEndpointIncomingEvent::LocalTrackEvent(track, event) => {
+                if *track == self.virtual_track_id {
+                    if let ClusterLocalTrackIncomingEvent::MediaPacket(track_uuid, pkt) = event {
+                        self.mixer.push_pkt(now_ms, *track_uuid, pkt);
+                        //TODO avid clone
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn pop_action(&mut self) -> Option<MediaEndpointMiddlewareOutput> {
+        while let Some(out) = self.mixer.pop() {
+            match out {
+                AudioMixerOutput::SlotPinned(_, _) => {
+                    //TODO fire event to client
+                }
+                AudioMixerOutput::SlotUnpinned(_, _) => {
+                    //TODO fire event to client
+                }
+                AudioMixerOutput::OutputSlotSrcChanged(_, _) => {
+                    //TODO fire event to client
+                }
+                AudioMixerOutput::OutputSlotPkt(slot, pkt) => {
+                    if let Some(Some(track_id)) = self.output_slots.get(slot) {
+                        //TODO rewrite ts and seq
+                        self.outputs.push_back(MediaEndpointMiddlewareOutput::Endpoint(TransportOutgoingEvent::LocalTrackEvent(
+                            *track_id,
+                            LocalTrackOutgoingEvent::MediaPacket(pkt),
+                        )));
+                    }
+                }
+            }
+        }
+
+        self.outputs.pop_front()
+    }
+}

--- a/packages/media-utils/src/seq_rewrite.rs
+++ b/packages/media-utils/src/seq_rewrite.rs
@@ -1,5 +1,6 @@
 use sorted_vec::SortedSet;
 
+#[derive(Clone)]
 pub struct SeqRewrite<const MAX: u64, const DROPPED_QUEUE_LEN: usize> {
     base: u64,
     max_output: u64,

--- a/packages/media-utils/src/ts_rewriter.rs
+++ b/packages/media-utils/src/ts_rewriter.rs
@@ -1,9 +1,11 @@
+#[derive(Clone)]
 enum State {
     FirstInit,
     Reinit,
     Rewriting,
 }
 
+#[derive(Clone)]
 pub struct TsRewrite<const TS_LIMIT: u64, const TS_DELTA_REINIT: u64> {
     data_rate: u64,
     delta_ts: i64,

--- a/packages/transport/src/packet.rs
+++ b/packages/transport/src/packet.rs
@@ -2,11 +2,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::PayloadCodec;
 
-// #[derive(Debug, Clone, PartialEq, Eq)]
-// pub struct MediaPacketExtensions {
-//     pub abs_send_time: Option<(i64, i64)>,
-//     pub transport_cc: Option<u16>, // (buf[0] << 8) | buf[1];
-// }
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaPacketExtensions {
+    pub audio_level: Option<i8>,
+}
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MediaPacket {
@@ -14,7 +13,7 @@ pub struct MediaPacket {
     pub seq_no: u16,
     pub time: u32,
     pub marker: bool,
-    // pub ext_vals: MediaPacketExtensions,
+    pub ext_vals: MediaPacketExtensions,
     pub nackable: bool,
     pub payload: Vec<u8>,
 }
@@ -26,10 +25,7 @@ impl MediaPacket {
             seq_no,
             time,
             marker: false,
-            // ext_vals: MediaPacketExtensions {
-            //     abs_send_time: None,
-            //     transport_cc: None,
-            // },
+            ext_vals: MediaPacketExtensions { audio_level: None },
             nackable: false,
             payload,
         }
@@ -41,10 +37,7 @@ impl MediaPacket {
             seq_no,
             time,
             marker: false,
-            // ext_vals: MediaPacketExtensions {
-            //     abs_send_time: None,
-            //     transport_cc: None,
-            // },
+            ext_vals: MediaPacketExtensions { audio_level: None },
             nackable: false,
             payload,
         }

--- a/servers/media-server/src/server/rtmp/session.rs
+++ b/servers/media-server/src/server/rtmp/session.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use async_std::{channel::Receiver, prelude::FutureExt as _};
-use cluster::{Cluster, ClusterEndpoint, EndpointSubscribeScope};
+use cluster::{Cluster, ClusterEndpoint, EndpointSubscribeScope, MixMinusAudioMode};
 use endpoint::{BitrateLimiterType, MediaEndpoint, MediaEndpointOutput, MediaEndpointPreconditional};
 use futures::{select, FutureExt};
 use media_utils::ErrorDebugger;
@@ -24,7 +24,7 @@ pub(super) struct RtmpSession<E: ClusterEndpoint> {
 
 impl<E: ClusterEndpoint> RtmpSession<E> {
     pub async fn new<C: Cluster<E>>(room: &str, peer: &str, cluster: &mut C, transport: RtmpTransport, rx: Receiver<InternalControl>) -> Result<Self, RtmpSessionError> {
-        let mut endpoint_pre = MediaEndpointPreconditional::new(room, peer, EndpointSubscribeScope::RoomManual, BitrateLimiterType::MaxBitrateOnly);
+        let mut endpoint_pre = MediaEndpointPreconditional::new(room, peer, EndpointSubscribeScope::RoomManual, BitrateLimiterType::MaxBitrateOnly, MixMinusAudioMode::Disabled, 0);
         endpoint_pre.check().map_err(|_e| RtmpSessionError::PreconditionError)?;
         let room = cluster.build(room, peer);
         let endpoint = endpoint_pre.build(transport, room);

--- a/servers/media-server/src/server/sip/sip_in_session.rs
+++ b/servers/media-server/src/server/sip/sip_in_session.rs
@@ -1,5 +1,5 @@
-use cluster::EndpointSubscribeScope;
 use cluster::{Cluster, ClusterEndpoint};
+use cluster::{EndpointSubscribeScope, MixMinusAudioMode};
 use endpoint::{BitrateLimiterType, MediaEndpoint, MediaEndpointOutput, MediaEndpointPreconditional};
 use transport_sip::SipTransportIn;
 
@@ -14,7 +14,14 @@ pub struct SipInSession<E: ClusterEndpoint> {
 
 impl<E: ClusterEndpoint> SipInSession<E> {
     pub async fn new<C: Cluster<E>>(room: &str, peer: &str, cluster: &mut C, transport: SipTransportIn) -> Result<Self, SipInSessionError> {
-        let mut endpoint_pre = MediaEndpointPreconditional::new(room, peer, EndpointSubscribeScope::RoomManual, BitrateLimiterType::DynamicWithConsumers);
+        let mut endpoint_pre = MediaEndpointPreconditional::new(
+            room,
+            peer,
+            EndpointSubscribeScope::RoomManual,
+            BitrateLimiterType::DynamicWithConsumers,
+            MixMinusAudioMode::AllAudioStreams,
+            1,
+        );
         endpoint_pre.check().map_err(|_e| SipInSessionError::PreconditionError)?;
         let room = cluster.build(room, peer);
         let endpoint = endpoint_pre.build(transport, room);

--- a/servers/media-server/src/server/sip/sip_out_session.rs
+++ b/servers/media-server/src/server/sip/sip_out_session.rs
@@ -1,5 +1,5 @@
-use cluster::EndpointSubscribeScope;
 use cluster::{Cluster, ClusterEndpoint};
+use cluster::{EndpointSubscribeScope, MixMinusAudioMode};
 use endpoint::{BitrateLimiterType, MediaEndpoint, MediaEndpointOutput, MediaEndpointPreconditional};
 use transport_sip::SipTransportOut;
 
@@ -14,7 +14,14 @@ pub struct SipOutSession<E: ClusterEndpoint> {
 
 impl<E: ClusterEndpoint> SipOutSession<E> {
     pub async fn new<C: Cluster<E>>(room: &str, peer: &str, cluster: &mut C, transport: SipTransportOut) -> Result<Self, SipOutSessionError> {
-        let mut endpoint_pre = MediaEndpointPreconditional::new(room, peer, EndpointSubscribeScope::RoomManual, BitrateLimiterType::DynamicWithConsumers);
+        let mut endpoint_pre = MediaEndpointPreconditional::new(
+            room,
+            peer,
+            EndpointSubscribeScope::RoomManual,
+            BitrateLimiterType::DynamicWithConsumers,
+            MixMinusAudioMode::AllAudioStreams,
+            1,
+        );
         endpoint_pre.check().map_err(|_e| SipOutSessionError::PreconditionError)?;
         let room = cluster.build(room, peer);
         let endpoint = endpoint_pre.build(transport, room);

--- a/servers/media-server/src/server/webrtc.rs
+++ b/servers/media-server/src/server/webrtc.rs
@@ -11,7 +11,7 @@ use cluster::{
         whip::WhipConnectResponse,
         RpcEmitter, RpcEndpoint, RpcReqRes, RpcRequest, RPC_NODE_PING,
     },
-    Cluster, ClusterEndpoint, EndpointSubscribeScope, RemoteBitrateControlMode, INNER_GATEWAY_SERVICE,
+    Cluster, ClusterEndpoint, EndpointSubscribeScope, MixMinusAudioMode, RemoteBitrateControlMode, INNER_GATEWAY_SERVICE,
 };
 use endpoint::BitrateLimiterType;
 use futures::{select, FutureExt};
@@ -185,6 +185,8 @@ where
                         },
                     ],
                     None,
+                    MixMinusAudioMode::Disabled,
+                    0,
                 )
                 .await
                 {
@@ -242,6 +244,8 @@ where
                     &sdp,
                     vec![],
                     Some(SdpBoxRewriteScope::OnlyTrack),
+                    MixMinusAudioMode::AllAudioStreams,
+                    1,
                 )
                 .await
                 {
@@ -299,6 +303,8 @@ where
                     &sdp,
                     param.senders.clone(),
                     Some(SdpBoxRewriteScope::StreamAndTrack),
+                    param.mix_minus_audio.unwrap_or(MixMinusAudioMode::Disabled),
+                    3,
                 )
                 .await
                 {

--- a/transports/webrtc/src/transport/internal.rs
+++ b/transports/webrtc/src/transport/internal.rs
@@ -173,8 +173,6 @@ where
                 if let Some(mid) = self.remote_video_mids.first() {
                     log::debug!("[TransportWebrtc] request ingress bitrate: {} with first video mid {}", bitrate, mid);
                     self.str0m_actions.push_back(Str0mAction::LimitIngressBitrate { mid: mid.clone(), max: bitrate });
-                } else {
-                    log::warn!("[TransportWebrtc] request ingress bitrate: {} but no video mid", bitrate);
                 }
             }
             TransportOutgoingEvent::ConfigEgressBitrate { current, desired } => {

--- a/transports/webrtc/src/transport/rtp_packet_convert.rs
+++ b/transports/webrtc/src/transport/rtp_packet_convert.rs
@@ -1,6 +1,6 @@
 use self::rid_history::RidHistory;
 use str0m::{format::CodecConfig, media::Pt};
-use transport::{H264Profile, MediaPacket, PayloadCodec, Vp9Profile};
+use transport::{H264Profile, MediaPacket, MediaPacketExtensions, PayloadCodec, Vp9Profile};
 
 use super::{
     mid_convert::rid_to_u16,
@@ -80,10 +80,9 @@ impl RtpPacketConverter {
             seq_no: rtp.header.sequence_number,
             time: rtp.header.timestamp,
             marker: rtp.header.marker,
-            // ext_vals: MediaPacketExtensions {
-            //     abs_send_time: rtp.header.ext_vals.abs_send_time.map(|t| (t.number(), t.denom())),
-            //     transport_cc: rtp.header.ext_vals.transport_cc,
-            // },
+            ext_vals: MediaPacketExtensions {
+                audio_level: rtp.header.ext_vals.audio_level,
+            },
             nackable: nackable,
             payload: rtp.payload,
         })


### PR DESCRIPTION
This PR implements an audio mixer with a mix-minus mechanism. This allows for semi-mixed audio in large conference rooms without decoding and encoding audio codecs.

The main idea is to select the tracks with the highest audio levels and send them to the client. These tracks are automatically switched on the server side without any control from the client. Additionally, the client can adjust which source track they are interested in, which is very useful in open-workspace applications like Gather.town.