### PR TITLE
fix: wrong track_id convert from random webrtc Mid

### DIFF
--- a/transports/webrtc/src/transport.rs
+++ b/transports/webrtc/src/transport.rs
@@ -143,7 +143,8 @@ where
                         }
                     }
                 },
-                Str0mAction::Media(mid, seq_no, mut pkt) => {
+                Str0mAction::Media(track_id, seq_no, mut pkt) => {
+                    let mid = self.event_convert.mid_for_track(track_id).cloned().expect("Should has mid");
                     if let Some(stream) = self.rtc.direct_api().stream_tx_by_mid(mid, None) {
                         self.pkt_convert.rewrite_codec(&mut pkt);
                         stream
@@ -163,7 +164,8 @@ where
                         debug_assert!(false, "should not missing mid");
                     }
                 }
-                Str0mAction::RequestKeyFrame(mid, kind) => {
+                Str0mAction::RequestKeyFrame(track_id, kind) => {
+                    let mid = self.event_convert.mid_for_track(track_id).cloned().expect("Should has mid");
                     if let Some(stream) = self.rtc.direct_api().stream_rx_by_mid(mid, None) {
                         match kind {
                             RequestKeyframeKind::Pli => stream.request_keyframe(KeyframeRequestKind::Pli),
@@ -194,7 +196,8 @@ where
                     bwe.set_current_bitrate(Bitrate::bps(current as u64));
                     bwe.set_desired_bitrate(Bitrate::bps(desired as u64));
                 }
-                Str0mAction::LimitIngressBitrate { mid, max } => {
+                Str0mAction::LimitIngressBitrate { track_id, max } => {
+                    let mid = self.event_convert.mid_for_track(track_id).cloned().expect("Should has mid");
                     if let Some(stream) = self.rtc.direct_api().stream_rx_by_mid(mid, None) {
                         log::debug!("[TransportWebrtc] on limit ingress bitrate mid {} max {}", mid, max);
                         stream.request_remb(Bitrate::bps(max as u64));

--- a/transports/webrtc/src/transport/internal/local_track_id_generator.rs
+++ b/transports/webrtc/src/transport/internal/local_track_id_generator.rs
@@ -1,28 +1,29 @@
-use str0m::media::{MediaKind, Mid};
+use str0m::media::MediaKind;
+use transport::TrackId;
 
 #[derive(Default)]
 pub struct LocalTrackIdGenerator {
-    audio_mids: Vec<Mid>,
-    video_mids: Vec<Mid>,
+    audio_tracks: Vec<TrackId>,
+    video_tracks: Vec<TrackId>,
 }
 
 impl LocalTrackIdGenerator {
     /// generate track id for local track with format kind_index
     /// index is the index of the track in the list of tracks of the same kind
-    pub fn generate(&mut self, kind: MediaKind, mid: Mid) -> String {
+    pub fn generate(&mut self, kind: MediaKind, track_id: TrackId) -> String {
         match kind {
             MediaKind::Audio => {
-                let index = self.audio_mids.iter().position(|m| *m == mid).unwrap_or_else(|| {
-                    let index = self.audio_mids.len();
-                    self.audio_mids.push(mid);
+                let index = self.audio_tracks.iter().position(|m| *m == track_id).unwrap_or_else(|| {
+                    let index = self.audio_tracks.len();
+                    self.audio_tracks.push(track_id);
                     index
                 });
                 format!("audio_{}", index)
             }
             MediaKind::Video => {
-                let index = self.video_mids.iter().position(|m| *m == mid).unwrap_or_else(|| {
-                    let index = self.video_mids.len();
-                    self.video_mids.push(mid);
+                let index = self.video_tracks.iter().position(|m| *m == track_id).unwrap_or_else(|| {
+                    let index = self.video_tracks.len();
+                    self.video_tracks.push(track_id);
                     index
                 });
                 format!("video_{}", index)
@@ -36,38 +37,38 @@ mod tests {
     #[test]
     fn in_order() {
         let mut generator = super::LocalTrackIdGenerator::default();
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "a".into()), "audio_0");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "b".into()), "audio_1");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "c".into()), "audio_2");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 100), "audio_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 200), "audio_1");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 300), "audio_2");
 
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "a".into()), "video_0");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "b".into()), "video_1");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "c".into()), "video_2");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 100), "video_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 200), "video_1");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 300), "video_2");
     }
 
     #[test]
     fn in_order2() {
         let mut generator = super::LocalTrackIdGenerator::default();
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "a".into()), "audio_0");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "a".into()), "video_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 100), "audio_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 100), "video_0");
 
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "b".into()), "audio_1");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "c".into()), "audio_2");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 200), "audio_1");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 300), "audio_2");
 
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "b".into()), "video_1");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "c".into()), "video_2");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 200), "video_1");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 300), "video_2");
     }
 
     #[test]
     fn reuse() {
         let mut generator = super::LocalTrackIdGenerator::default();
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "a".into()), "audio_0");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "a".into()), "video_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 100), "audio_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 100), "video_0");
 
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "b".into()), "audio_1");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, "a".into()), "audio_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 200), "audio_1");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Audio, 100), "audio_0");
 
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "b".into()), "video_1");
-        assert_eq!(generator.generate(str0m::media::MediaKind::Video, "a".into()), "video_0");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 200), "video_1");
+        assert_eq!(generator.generate(str0m::media::MediaKind::Video, 100), "video_0");
     }
 }

--- a/transports/webrtc/src/transport/mid_convert.rs
+++ b/transports/webrtc/src/transport/mid_convert.rs
@@ -1,16 +1,31 @@
 use str0m::media::{Mid, Rid};
 use transport::TrackId;
 
-const ZERO_CHAR: u8 = 48;
+const ZERO_CHAR: u8 = b'0';
 
-//TODO optimize this
-pub fn mid_to_track(mid: &Mid) -> TrackId {
-    let mut track = 0;
-    for c in mid.as_bytes() {
-        track *= 10;
-        track += (*c - ZERO_CHAR) as u16;
+#[derive(Default)]
+pub struct MidMapper {
+    cache: Vec<Mid>,
+}
+
+impl MidMapper {
+    /// Returns the mid for the given track id.
+    /// If the track id is not known, a new mid is generated and returned.
+    /// If the track id is known, the corresponding mid is returned.
+    pub fn mid_to_track(&mut self, mid: Mid) -> TrackId {
+        let index = self.cache.iter().position(|m| *m == mid);
+        match index {
+            Some(index) => index as TrackId,
+            None => {
+                self.cache.push(mid);
+                (self.cache.len() - 1) as TrackId
+            }
+        }
     }
-    track
+
+    pub fn track_to_mid(&self, track_id: TrackId) -> Option<&Mid> {
+        self.cache.get(track_id as usize)
+    }
 }
 
 pub fn rid_to_u16(rid: &Rid) -> TrackId {
@@ -23,7 +38,7 @@ pub fn rid_to_u16(rid: &Rid) -> TrackId {
 }
 
 //TODO optimize this
-pub fn track_to_mid(track_id: TrackId) -> Mid {
+pub fn generate_mid(track_id: TrackId) -> Mid {
     if track_id < 10 {
         Mid::from_array([track_id as u8 + ZERO_CHAR, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32])
     } else if track_id < 100 {
@@ -75,9 +90,15 @@ mod tests {
 
     #[test]
     fn test_mid_to_track() {
-        let mid = Mid::from("100");
-        let track = mid_to_track(&mid);
-        assert_eq!(track, 100);
+        let mut mapper = MidMapper::default();
+        assert_eq!(mapper.mid_to_track(Mid::from("100")), 0);
+        assert_eq!(mapper.mid_to_track(Mid::from("101")), 1);
+        assert_eq!(mapper.mid_to_track(Mid::from("100")), 0);
+
+        //convert back
+        assert_eq!(mapper.track_to_mid(0), Some(&Mid::from("100")));
+        assert_eq!(mapper.track_to_mid(1), Some(&Mid::from("101")));
+        assert_eq!(mapper.track_to_mid(2), None);
     }
 
     #[test]
@@ -85,12 +106,5 @@ mod tests {
         let rid = Rid::from("100");
         let value = rid_to_u16(&rid);
         assert_eq!(value, 100);
-    }
-
-    #[test]
-    fn test_track_to_mid() {
-        let track_id = 100;
-        let mid = track_to_mid(track_id);
-        assert_eq!(mid, Mid::from("100"));
     }
 }


### PR DESCRIPTION
This PR fix webrtc track_id rule by mapping Mid [u8; 16] in a HashMap. Previously version convert directly [u8; 16] to u16 that cannot work correctly with random Mid, which is used by some webrtc-client