### PR TITLE
fix: whip/whep sdp patch with client ices failed #176

### DIFF
--- a/packages/cluster/src/define/rpc/webrtc.rs
+++ b/packages/cluster/src/define/rpc/webrtc.rs
@@ -86,13 +86,13 @@ pub struct WebrtcRemoteIceResponse {
     pub success: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
 pub struct WebrtcPatchRequest {
     pub conn_id: String,
     pub sdp: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, IntoVecU8, TryFromSliceU8)]
 pub struct WebrtcPatchResponse {
-    pub sdp: String,
+    pub ice_restart_sdp: Option<String>,
 }

--- a/servers/media-server/src/rpc/http.rs
+++ b/servers/media-server/src/rpc/http.rs
@@ -15,7 +15,7 @@ mod user_agent;
 
 pub use authorization::TokenAuthorization;
 pub use embeded_endpoint::EmbeddedFilesEndpoint;
-pub use payload_sdp::{ApplicationSdp, HttpResponse};
+pub use payload_sdp::{ApplicationSdp, ApplicationSdpPatch, CustomHttpResponse};
 pub use remote_ip_addr::RemoteIpAddr;
 pub use rpc_req::RpcReqResHttp;
 pub use user_agent::UserAgent;

--- a/servers/media-server/src/rpc/http/payload_sdp.rs
+++ b/servers/media-server/src/rpc/http/payload_sdp.rs
@@ -79,13 +79,79 @@ impl<T: Into<String> + Send> ApiResponse for ApplicationSdp<T> {
     fn register(_registry: &mut Registry) {}
 }
 
-pub struct HttpResponse<T: IntoResponse> {
+/// A UTF8 string payload.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ApplicationSdpPatch<T>(pub T);
+
+impl<T> Deref for ApplicationSdpPatch<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for ApplicationSdpPatch<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Send> Payload for ApplicationSdpPatch<T> {
+    const CONTENT_TYPE: &'static str = "application/trickle-ice-sdpfrag";
+
+    fn check_content_type(content_type: &str) -> bool {
+        match content_type {
+            "application/trickle-ice-sdpfrag" => true,
+            _ => false,
+        }
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        String::schema_ref()
+    }
+}
+
+#[poem::async_trait]
+impl ParsePayload for ApplicationSdpPatch<String> {
+    const IS_REQUIRED: bool = true;
+
+    async fn from_request(request: &Request, body: &mut RequestBody) -> Result<Self> {
+        Ok(Self(String::from_request(request, body).await?))
+    }
+}
+
+impl<T: Into<String> + Send> IntoResponse for ApplicationSdpPatch<T> {
+    fn into_response(self) -> Response {
+        self.0.into().into_response()
+    }
+}
+
+impl<T: Into<String> + Send> ApiResponse for ApplicationSdpPatch<T> {
+    fn meta() -> MetaResponses {
+        MetaResponses {
+            responses: vec![MetaResponse {
+                description: "",
+                status: Some(200),
+                content: vec![MetaMediaType {
+                    content_type: Self::CONTENT_TYPE,
+                    schema: Self::schema_ref(),
+                }],
+                headers: vec![],
+            }],
+        }
+    }
+
+    fn register(_registry: &mut Registry) {}
+}
+
+pub struct CustomHttpResponse<T: IntoResponse> {
     pub code: StatusCode,
     pub res: T,
     pub headers: Vec<(&'static str, String)>,
 }
 
-impl<T: IntoResponse> IntoResponse for HttpResponse<T> {
+impl<T: IntoResponse> IntoResponse for CustomHttpResponse<T> {
     fn into_response(self) -> Response {
         let mut res = self.res.into_response();
         for (k, v) in self.headers {
@@ -98,7 +164,7 @@ impl<T: IntoResponse> IntoResponse for HttpResponse<T> {
     }
 }
 
-impl<T: Payload + IntoResponse> ApiResponse for HttpResponse<T> {
+impl<T: Payload + IntoResponse> ApiResponse for CustomHttpResponse<T> {
     fn meta() -> MetaResponses {
         MetaResponses {
             responses: vec![MetaResponse {
@@ -117,3 +183,4 @@ impl<T: Payload + IntoResponse> ApiResponse for HttpResponse<T> {
 }
 
 impl_apirequest_for_payload!(ApplicationSdp<String>);
+impl_apirequest_for_payload!(ApplicationSdpPatch<String>);

--- a/transports/webrtc/src/transport/internal/utils.rs
+++ b/transports/webrtc/src/transport/internal/utils.rs
@@ -6,3 +6,71 @@ pub fn to_transport_kind(value: MediaKind) -> transport::MediaKind {
         MediaKind::Video => transport::MediaKind::Video,
     }
 }
+
+/// Convert a SDP patch to ICE candidates.
+/// When received:
+///
+/// ```
+/// a=ice-ufrag:EsAw
+/// a=ice-pwd:P2uYro0UCOQ4zxjKXaWCBui1
+/// a=group:BUNDLE 0 1
+/// m=audio 9 UDP/TLS/RTP/SAVPF 111
+/// a=mid:0
+/// a=candidate:1387637174 1 udp 2122260223 192.0.2.1 61764 typ host generation 0 ufrag EsAw network-id 1
+/// a=candidate:3471623853 1 udp 2122194687 198.51.100.1 61765 typ host generation 0 ufrag EsAw network-id 2
+/// a=candidate:473322822 1 tcp 1518280447 192.0.2.1 9 typ host tcptype active generation 0 ufrag EsAw network-id 1
+/// a=candidate:2154773085 1 tcp 1518214911 198.51.100.2 9 typ host tcptype active generation 0 ufrag EsAw network-id 2
+/// a=end-of-candidates
+/// ```
+///
+/// Should return list of ICE candidates:
+///
+/// ```
+/// [
+///    "candidate:1387637174 1 udp 2122260223 192.0.2.1 61764 typ host generation 0 ufrag EsAw network-id 1",
+///    ....
+/// ]
+/// ```
+pub fn sdp_patch_to_ices(patch: &str) -> Vec<String> {
+    let mut candidates = vec![];
+    for line in patch.lines() {
+        if line.starts_with("a=candidate:") {
+            candidates.push(line[2..].to_owned());
+        }
+    }
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_transport_kind() {
+        assert_eq!(to_transport_kind(MediaKind::Audio), transport::MediaKind::Audio);
+        assert_eq!(to_transport_kind(MediaKind::Video), transport::MediaKind::Video);
+    }
+
+    #[test]
+    fn test_sdp_patch_to_ices() {
+        let patch = "a=ice-ufrag:EsAw\n\
+                     a=ice-pwd:P2uYro0UCOQ4zxjKXaWCBui1\n\
+                     a=group:BUNDLE 0 1\n\
+                     m=audio 9 UDP/TLS/RTP/SAVPF 111\n\
+                     a=mid:0\n\
+                     a=candidate:1387637174 1 udp 2122260223 192.0.2.1 61764 typ host generation 0 ufrag EsAw network-id 1\n\
+                     a=candidate:3471623853 1 udp 2122194687 198.51.100.1 61765 typ host generation 0 ufrag EsAw network-id 2\n\
+                     a=candidate:473322822 1 tcp 1518280447 192.0.2.1 9 typ host tcptype active generation 0 ufrag EsAw network-id 1\n\
+                     a=candidate:2154773085 1 tcp 1518214911 198.51.100.2 9 typ host tcptype active generation 0 ufrag EsAw network-id 2\n\
+                     a=end-of-candidates";
+
+        let expected_candidates = vec![
+            "candidate:1387637174 1 udp 2122260223 192.0.2.1 61764 typ host generation 0 ufrag EsAw network-id 1".to_owned(),
+            "candidate:3471623853 1 udp 2122194687 198.51.100.1 61765 typ host generation 0 ufrag EsAw network-id 2".to_owned(),
+            "candidate:473322822 1 tcp 1518280447 192.0.2.1 9 typ host tcptype active generation 0 ufrag EsAw network-id 1".to_owned(),
+            "candidate:2154773085 1 tcp 1518214911 198.51.100.2 9 typ host tcptype active generation 0 ufrag EsAw network-id 2".to_owned(),
+        ];
+
+        assert_eq!(sdp_patch_to_ices(patch), expected_candidates);
+    }
+}


### PR DESCRIPTION
This PR fix issue #176

Changes:

- Allow "application/trickle-ice-sdpfrag" payload-type
- Process ice-remote candidates from patch request