### PR TITLE
feat: gateway global

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,8 @@ jobs:
     needs: build-release
     runs-on: ubuntu-latest
     steps:
+      - name: Download maxminddb
+        run: sh download-geodata.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 tarpaulin-report.html
 .atm0s
+/maxminddb-data
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "clap",
  "futures",
  "log",
+ "maxminddb",
  "md5",
  "metrics",
  "metrics-dashboard",
@@ -2331,6 +2332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,6 +2559,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "maxminddb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6087e5d8ea14861bb7c7f573afbc7be3798d3ef0fae87ec4fd9a4de9a127c3c"
+dependencies = [
+ "ipnetwork",
+ "log",
+ "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN case $TARGETPLATFORM in \
 
 FROM ubuntu:22.04
 
+COPY maxminddb-data /maxminddb-data
 COPY --from=base /atm0s-media-server /atm0s-media-server
 
 ENTRYPOINT ["/atm0s-media-server"]

--- a/docs/servers/gateway.md
+++ b/docs/servers/gateway.md
@@ -1,0 +1,11 @@
+# Gateway Server
+
+The Gateway Server holds a list of resources. There are two types of gateways: zone-level gateways, which hold all servers within their zone, and global gateways, which hold all zone gateways. Gateways act as routers, directing user requests to the best or destination node based on the request type and parameters.
+
+### Inner Gateway
+
+This gateway is used to route a request to the best node inside a zone.
+
+### Global Gateway
+
+This gateway is used to route a request to the closest zone to the user. To determine the user's location, we use the free maxmind-db geo-ip. You can download it by running the script `download-geodata.sh`.

--- a/download-geodata.sh
+++ b/download-geodata.sh
@@ -1,0 +1,4 @@
+mkdir -p maxminddb-data
+cd maxminddb-data
+rm *
+wget https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb

--- a/download-geodata.sh
+++ b/download-geodata.sh
@@ -1,4 +1,4 @@
 mkdir -p maxminddb-data
 cd maxminddb-data
-rm *
-wget https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb
+rm -i GeoLite2-City.mmdb
+wget https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb || { echo "Download GeoLite2-City database failed"; exit 1; }

--- a/packages/cluster/src/define/rpc/gateway.rs
+++ b/packages/cluster/src/define/rpc/gateway.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use media_utils::F32;
 use proc_macro::{IntoVecU8, TryFromSliceU8};
 use serde::{Deserialize, Serialize};
 
@@ -15,6 +16,8 @@ pub struct ServiceInfo {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, IntoVecU8, TryFromSliceU8)]
 pub struct NodePing {
     pub node_id: u32,
+    pub group: String,
+    pub location: Option<(F32<2>, F32<2>)>,
     pub webrtc: Option<ServiceInfo>,
     pub rtmp: Option<ServiceInfo>,
     pub sip: Option<ServiceInfo>,

--- a/packages/cluster/src/define/rpc/gateway.rs
+++ b/packages/cluster/src/define/rpc/gateway.rs
@@ -1,8 +1,12 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
+use atm0s_sdn::NodeId;
 use media_utils::F32;
+use poem_openapi::Object;
 use proc_macro::{IntoVecU8, TryFromSliceU8};
 use serde::{Deserialize, Serialize};
+
+use super::general::MediaSessionProtocol;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServiceInfo {
@@ -38,6 +42,18 @@ pub enum NodeHealthcheckRequest {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, IntoVecU8, TryFromSliceU8)]
 pub struct NodeHealthcheckResponse {
     pub success: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
+pub struct QueryBestNodesRequest {
+    pub ip_addr: IpAddr,
+    pub protocol: MediaSessionProtocol,
+    pub size: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
+pub struct QueryBestNodesResponse {
+    pub nodes: Vec<NodeId>,
 }
 
 //TODO test this

--- a/packages/cluster/src/define/rpc/general.rs
+++ b/packages/cluster/src/define/rpc/general.rs
@@ -1,4 +1,4 @@
-use poem_openapi::Object;
+use poem_openapi::{Enum, Object};
 use proc_macro::{IntoVecU8, TryFromSliceU8};
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +12,7 @@ pub struct MediaEndpointCloseResponse {
     pub success: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Enum, PartialEq, Eq, Clone, Copy)]
 pub enum MediaSessionProtocol {
     Whip,
     Whep,

--- a/packages/cluster/src/define/rpc/webrtc.rs
+++ b/packages/cluster/src/define/rpc/webrtc.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, net::IpAddr};
 
 use crate::{ClusterEndpointPublishScope, ClusterEndpointSubscribeScope, MediaSessionToken, VerifyObject};
 
@@ -26,8 +26,8 @@ pub struct WebrtcConnectRequestSender {
 #[derive(Debug, Serialize, Deserialize, Object, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
 pub struct WebrtcConnectRequest {
     pub session_uuid: Option<u64>,
-    pub ip_addr: Option<String>,
-    pub user_agent: Option<String>,
+    pub ip_addr: IpAddr,
+    pub user_agent: String,
     pub version: Option<String>,
     pub room: String,
     pub peer: String,

--- a/packages/cluster/src/define/rpc/whep.rs
+++ b/packages/cluster/src/define/rpc/whep.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 use proc_macro::{IntoVecU8, TryFromSliceU8};
 use serde::{Deserialize, Serialize};
 
@@ -6,7 +8,7 @@ use crate::VerifyObject;
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
 pub struct WhepConnectRequest {
     pub session_uuid: u64,
-    pub ip_addr: String,
+    pub ip_addr: IpAddr,
     pub user_agent: String,
     pub token: String,
     pub sdp: Option<String>,

--- a/packages/cluster/src/define/rpc/whip.rs
+++ b/packages/cluster/src/define/rpc/whip.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 use proc_macro::{IntoVecU8, TryFromSliceU8};
 use serde::{Deserialize, Serialize};
 
@@ -6,7 +8,7 @@ use crate::{MediaSessionToken, VerifyObject};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, IntoVecU8, TryFromSliceU8, Clone)]
 pub struct WhipConnectRequest {
     pub session_uuid: u64,
-    pub ip_addr: String,
+    pub ip_addr: IpAddr,
     pub user_agent: String,
     pub token: String,
     pub sdp: Option<String>,

--- a/packages/cluster/src/implement/mod.rs
+++ b/packages/cluster/src/implement/mod.rs
@@ -33,6 +33,8 @@ mod tests {
             ServerSdnConfig {
                 secret: "static_key".to_string(),
                 seeds: vec![],
+                connect_tags: vec!["local".to_string()],
+                local_tags: vec!["local".to_string()],
             },
         )
         .await;
@@ -109,6 +111,8 @@ mod tests {
             ServerSdnConfig {
                 secret: "static_key".to_string(),
                 seeds: vec![],
+                connect_tags: vec!["local".to_string()],
+                local_tags: vec!["local".to_string()],
             },
         )
         .await;
@@ -185,6 +189,8 @@ mod tests {
             ServerSdnConfig {
                 secret: "static_key".to_string(),
                 seeds: vec![],
+                connect_tags: vec!["local".to_string()],
+                local_tags: vec!["local".to_string()],
             },
         )
         .await;
@@ -259,6 +265,8 @@ mod tests {
             ServerSdnConfig {
                 secret: "static_key".to_string(),
                 seeds: vec![],
+                connect_tags: vec!["local".to_string()],
+                local_tags: vec!["local".to_string()],
             },
         )
         .await;

--- a/packages/cluster/src/implement/server.rs
+++ b/packages/cluster/src/implement/server.rs
@@ -33,6 +33,8 @@ pub(crate) enum NodeSdkEvent {
 pub struct ServerSdnConfig {
     pub secret: String,
     pub seeds: Vec<NodeAddr>,
+    pub local_tags: Vec<String>,
+    pub connect_tags: Vec<String>,
 }
 
 compose_transport!(UdpTcpTransport, udp: UdpTransport, tcp: TcpTransport);
@@ -64,8 +66,8 @@ impl ServerSdn {
         let manual = ManualBehavior::new(ManualBehaviorConf {
             node_id,
             node_addr: node_addr_builder.addr(),
-            local_tags: vec!["media-server".to_string()],
-            connect_tags: vec!["inner-gateway".to_string()],
+            local_tags: config.local_tags,
+            connect_tags: config.connect_tags,
             seeds: config.seeds,
         });
 

--- a/packages/endpoint/src/endpoint/internal/local_track.rs
+++ b/packages/endpoint/src/endpoint/internal/local_track.rs
@@ -91,7 +91,7 @@ impl LocalTrack {
                 }
 
                 if let Some(pkt) = self.filter.process(now_ms, pkt) {
-                    log::info!("[LocalTrack {}] media from cluster pkt {:?} {}", self.track_name, pkt.codec, pkt.seq_no);
+                    log::debug!("[LocalTrack {}] media from cluster pkt {:?} {}", self.track_name, pkt.codec, pkt.seq_no);
                     self.out_actions.push_back(LocalTrackOutput::Transport(LocalTrackOutgoingEvent::MediaPacket(pkt)));
                 }
             }

--- a/packages/media-utils/src/float.rs
+++ b/packages/media-utils/src/float.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// This store float f32 as u32, and can be used as key in HashMap
 /// ACCURACY is the number of digits after the decimal point
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub struct F32<const ACCURACY: usize>(u32);
 
 impl<const ACCURACY: usize> F32<ACCURACY> {

--- a/servers/media-server/Cargo.toml
+++ b/servers/media-server/Cargo.toml
@@ -36,6 +36,7 @@ reqwest = { version = "0.11.23", features = ["default-tls", "json"], optional = 
 md5 = {version = "0.7.0", optional = true }
 rand = "0.8.5"
 yaque = { version = "0.6.6", optional = true }
+maxminddb = { version = "0.24.0", optional = true }
 
 [dev-dependencies]
 md5 = "0.7.0"
@@ -46,6 +47,6 @@ embed-samples = ["rust-embed"]
 webrtc = ["transport-webrtc"]
 rtmp = ["transport-rtmp"]
 sip = ["rsip", "transport-sip", "reqwest", "md5"]
-gateway = []
+gateway = ["maxminddb"]
 connector = ["nats", "prost", "yaque"]
 token_generate = []

--- a/servers/media-server/scripts/gateway_global.sh
+++ b/servers/media-server/scripts/gateway_global.sh
@@ -1,0 +1,7 @@
+cargo run --package atm0s-media-server -- \
+--node-id 1 \
+--http-port 8001 \
+--sdn-port 10001 \
+gateway \
+--mode global \
+--geoip-db ../../../maxminddb-data/GeoLite2-City.mmdb

--- a/servers/media-server/scripts/gateway_inner.sh
+++ b/servers/media-server/scripts/gateway_inner.sh
@@ -1,0 +1,11 @@
+cargo run --package atm0s-media-server -- \
+--node-id 11 \
+--http-port 8011 \
+--sdn-port 10011 \
+--sdn-group group1 \
+--seeds 1@/ip4/127.0.0.1/udp/10001/ip4/127.0.0.1/tcp/10001 \
+gateway \
+--mode inner \
+--group local \
+--lat 37.7749 \
+--lng 122.4194

--- a/servers/media-server/scripts/media_rtmp.sh
+++ b/servers/media-server/scripts/media_rtmp.sh
@@ -1,0 +1,7 @@
+cargo run --package atm0s-media-server -- \
+--node-id 21 \
+--http-port 8021 \
+--sdn-port 10021 \
+--sdn-group group1 \
+--seeds 11@/ip4/127.0.0.1/udp/10011/ip4/127.0.0.1/tcp/10011 \
+rtmp

--- a/servers/media-server/scripts/media_sip.sh
+++ b/servers/media-server/scripts/media_sip.sh
@@ -1,0 +1,7 @@
+cargo run --package atm0s-media-server -- \
+--node-id 31 \
+--http-port 8031 \
+--sdn-port 10031 \
+--sdn-group group1 \
+--seeds 11@/ip4/127.0.0.1/udp/10011/ip4/127.0.0.1/tcp/10011 \
+sip --addr 127.0.0.1:5060

--- a/servers/media-server/scripts/media_webrtc.sh
+++ b/servers/media-server/scripts/media_webrtc.sh
@@ -1,0 +1,7 @@
+cargo run --package atm0s-media-server -- \
+--node-id 41 \
+--http-port 8041 \
+--sdn-port 10041 \
+--sdn-group group1 \
+--seeds 11@/ip4/127.0.0.1/udp/10011/ip4/127.0.0.1/tcp/10011 \
+webrtc

--- a/servers/media-server/src/main.rs
+++ b/servers/media-server/src/main.rs
@@ -44,6 +44,10 @@ struct Args {
     #[arg(env, long, default_value_t = 0)]
     sdn_port: u16,
 
+    /// Sdn group
+    #[arg(env, long, default_value = "local")]
+    sdn_group: String,
+
     /// Current Node ID
     #[arg(env, long, default_value_t = 1)]
     node_id: NodeId,
@@ -83,9 +87,11 @@ async fn main() {
     }
     let args: Args = Args::parse();
     tracing_subscriber::registry().with(fmt::layer()).with(EnvFilter::from_default_env()).init();
-    let config = ServerSdnConfig {
+    let mut config = ServerSdnConfig {
         secret: args.secret.clone(),
         seeds: args.seeds,
+        local_tags: vec![],
+        connect_tags: vec![],
     };
 
     match args.server {
@@ -99,6 +105,17 @@ async fn main() {
         #[cfg(feature = "gateway")]
         Servers::Gateway(opts) => {
             use server::MediaServerContext;
+            match opts.mode {
+                GatewayMode::Global => {
+                    config.local_tags = vec!["gateway-global".to_string()];
+                    config.connect_tags = vec!["gateway-global".to_string()];
+                }
+                GatewayMode::Inner => {
+                    config.local_tags = vec![format!("gateway-inner-{}", args.sdn_group)];
+                    config.connect_tags = vec!["gateway-global".to_string(), format!("gateway-inner-{}", args.sdn_group)];
+                }
+            }
+
             let token = Arc::new(cluster::implement::jwt_static::JwtStaticToken::new(&args.secret));
             let ctx = MediaServerContext::<()>::new(args.node_id, 0, Arc::new(SystemTimer()), token.clone(), token);
             let rpc_service_id = match opts.mode {
@@ -113,6 +130,9 @@ async fn main() {
         #[cfg(feature = "webrtc")]
         Servers::Webrtc(opts) => {
             use server::MediaServerContext;
+            config.local_tags = vec![format!("media-webrtc-{}", args.sdn_group)];
+            config.connect_tags = vec![format!("gateway-inner-{}", args.sdn_group)];
+
             let token = Arc::new(cluster::implement::jwt_static::JwtStaticToken::new(&args.secret));
             let ctx = MediaServerContext::new(args.node_id, opts.max_conn, Arc::new(SystemTimer()), token.clone(), token);
             let (cluster, rpc_endpoint) = ServerSdn::new(args.node_id, args.sdn_port, MEDIA_SERVER_SERVICE, config).await;
@@ -123,6 +143,9 @@ async fn main() {
         #[cfg(feature = "rtmp")]
         Servers::Rtmp(opts) => {
             use server::MediaServerContext;
+            config.local_tags = vec![format!("media-rtmp-{}", args.sdn_group)];
+            config.connect_tags = vec![format!("gateway-inner-{}", args.sdn_group)];
+
             let token = Arc::new(cluster::implement::jwt_static::JwtStaticToken::new(&args.secret));
             let ctx = MediaServerContext::new(args.node_id, opts.max_conn, Arc::new(SystemTimer()), token.clone(), token);
             let (cluster, rpc_endpoint) = ServerSdn::new(args.node_id, args.sdn_port, MEDIA_SERVER_SERVICE, config).await;
@@ -133,6 +156,9 @@ async fn main() {
         #[cfg(feature = "sip")]
         Servers::Sip(opts) => {
             use server::MediaServerContext;
+            config.local_tags = vec![format!("media-sip-{}", args.sdn_group)];
+            config.connect_tags = vec![format!("gateway-inner-{}", args.sdn_group)];
+
             let token = Arc::new(cluster::implement::jwt_static::JwtStaticToken::new(&args.secret));
             let ctx = MediaServerContext::new(args.node_id, opts.max_conn, Arc::new(SystemTimer()), token.clone(), token);
             let (cluster, rpc_endpoint) = ServerSdn::new(args.node_id, args.sdn_port, MEDIA_SERVER_SERVICE, config).await;
@@ -143,6 +169,9 @@ async fn main() {
         #[cfg(feature = "connector")]
         Servers::Connector(opts) => {
             use server::MediaServerContext;
+            config.local_tags = vec![format!("connector-{}", args.sdn_group)];
+            config.connect_tags = vec![format!("gateway-inner-{}", args.sdn_group)];
+
             let token = Arc::new(cluster::implement::jwt_static::JwtStaticToken::new(&args.secret));
             let ctx = MediaServerContext::new(args.node_id, opts.max_conn, Arc::new(SystemTimer()), token.clone(), token);
             let (cluster, rpc_endpoint) = ServerSdn::new(args.node_id, args.sdn_port, CONNECTOR_SERVICE, config).await;

--- a/servers/media-server/src/main.rs
+++ b/servers/media-server/src/main.rs
@@ -8,7 +8,7 @@ mod server;
 use cluster::{
     atm0s_sdn::SystemTimer,
     implement::{NodeAddr, NodeId, ServerSdn, ServerSdnConfig},
-    CONNECTOR_SERVICE, INNER_GATEWAY_SERVICE, MEDIA_SERVER_SERVICE,
+    CONNECTOR_SERVICE, GLOBAL_GATEWAY_SERVICE, INNER_GATEWAY_SERVICE, MEDIA_SERVER_SERVICE,
 };
 
 #[cfg(feature = "connector")]
@@ -25,6 +25,8 @@ use server::token_generate::run_token_generate_server;
 use server::webrtc::run_webrtc_server;
 
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+use crate::server::gateway::GatewayMode;
 
 /// Media Server
 #[derive(Parser, Debug)]
@@ -99,7 +101,11 @@ async fn main() {
             use server::MediaServerContext;
             let token = Arc::new(cluster::implement::jwt_static::JwtStaticToken::new(&args.secret));
             let ctx = MediaServerContext::<()>::new(args.node_id, 0, Arc::new(SystemTimer()), token.clone(), token);
-            let (cluster, rpc_endpoint) = ServerSdn::new(args.node_id, args.sdn_port, INNER_GATEWAY_SERVICE, config).await;
+            let rpc_service_id = match opts.mode {
+                GatewayMode::Inner => INNER_GATEWAY_SERVICE,
+                GatewayMode::Global => GLOBAL_GATEWAY_SERVICE,
+            };
+            let (cluster, rpc_endpoint) = ServerSdn::new(args.node_id, args.sdn_port, rpc_service_id, config).await;
             if let Err(e) = run_gateway_server(args.http_port, args.http_tls, opts, ctx, cluster, rpc_endpoint).await {
                 log::error!("[GatewayServer] error {}", e);
             }

--- a/servers/media-server/src/rpc/http/remote_ip_addr.rs
+++ b/servers/media-server/src/rpc/http/remote_ip_addr.rs
@@ -12,10 +12,10 @@ impl<'a> FromRequest<'a> for RemoteIpAddr {
         if let Some(remote_addr) = headers.get("X-Forwarded-For") {
             let remote_addr = remote_addr.to_str().map_err(|_| poem::Error::from_string("Bad Request", StatusCode::BAD_REQUEST))?;
             let remote_addr = remote_addr.split(',').next().ok_or(poem::Error::from_string("Bad Request", StatusCode::BAD_REQUEST))?;
-            return Ok(RemoteIpAddr(remote_addr.parse().unwrap_or(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))));
+            return Ok(RemoteIpAddr(remote_addr.parse().map_err(|_| poem::Error::from_string("Invalid IP address", StatusCode::BAD_REQUEST))?));
         } else if let Some(remote_addr) = headers.get("X-Real-IP") {
             let remote_addr = remote_addr.to_str().map_err(|_| poem::Error::from_string("Bad Request", StatusCode::BAD_REQUEST))?;
-            return Ok(RemoteIpAddr(remote_addr.parse().unwrap_or(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))));
+            return Ok(RemoteIpAddr(remote_addr.parse().map_err(|_| poem::Error::from_string("Invalid IP address", StatusCode::BAD_REQUEST))?));
         } else {
             match req.remote_addr().deref() {
                 poem::Addr::SocketAddr(addr) => {

--- a/servers/media-server/src/server/connector.rs
+++ b/servers/media-server/src/server/connector.rs
@@ -107,7 +107,7 @@ where
         server_type: ServerType::CONNECTOR,
     };
 
-    let api_service = OpenApiService::new(ConnectorHttpApis, "Connector Server", "1.0.0").server(format!("http://localhost:{}", http_port));
+    let api_service = OpenApiService::new(ConnectorHttpApis, "Connector Server", env!("CARGO_PKG_VERSION")).server("/");
     let ui = api_service.swagger_ui();
     let spec = api_service.spec();
 

--- a/servers/media-server/src/server/gateway.rs
+++ b/servers/media-server/src/server/gateway.rs
@@ -3,15 +3,17 @@ use std::{sync::Arc, time::Duration};
 use async_std::stream::StreamExt;
 use clap::Parser;
 use cluster::{
+    implement::NodeId,
     rpc::{
+        gateway::{NodePing, NodePong},
         general::{MediaEndpointCloseRequest, MediaEndpointCloseResponse, NodeInfo, ServerType},
         webrtc::{WebrtcPatchRequest, WebrtcPatchResponse, WebrtcRemoteIceRequest, WebrtcRemoteIceResponse},
-        RpcEmitter, RpcEndpoint, RpcRequest, RPC_MEDIA_ENDPOINT_CLOSE, RPC_WEBRTC_CONNECT, RPC_WEBRTC_ICE, RPC_WEBRTC_PATCH, RPC_WHEP_CONNECT, RPC_WHIP_CONNECT,
+        RpcEmitter, RpcEndpoint, RpcRequest, RPC_MEDIA_ENDPOINT_CLOSE, RPC_NODE_PING, RPC_WEBRTC_CONNECT, RPC_WEBRTC_ICE, RPC_WEBRTC_PATCH, RPC_WHEP_CONNECT, RPC_WHIP_CONNECT,
     },
-    Cluster, ClusterEndpoint, MEDIA_SERVER_SERVICE,
+    Cluster, ClusterEndpoint, GLOBAL_GATEWAY_SERVICE, MEDIA_SERVER_SERVICE,
 };
 use futures::{select, FutureExt};
-use media_utils::{SystemTimer, Timer};
+use media_utils::{SystemTimer, Timer, F32};
 use metrics::describe_counter;
 use metrics_dashboard::build_dashboard_route;
 use poem::{web::Json, Route};
@@ -37,6 +39,7 @@ use self::{
     rpc::{cluster::GatewayClusterRpc, http::GatewayHttpApis, RpcEvent},
 };
 
+pub use self::logic::GatewayMode;
 use super::MediaServerContext;
 
 mod logic;
@@ -49,9 +52,25 @@ const GATEWAY_SESSIONS_CONNECT_ERROR: &str = "gateway.sessions.connect.error";
 /// Media Server Webrtc
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-pub struct GatewayArgs {}
+pub struct GatewayArgs {
+    /// Gateway mode
+    #[arg(value_enum, env, long, default_value_t = GatewayMode::Inner)]
+    pub mode: GatewayMode,
 
-pub async fn run_gateway_server<C, CR, RPC, REQ, EMITTER>(http_port: u16, http_tls: bool, _opts: GatewayArgs, ctx: MediaServerContext<()>, cluster: C, rpc_endpoint: RPC) -> Result<(), &'static str>
+    /// Gateway group, only set if mode is Inner
+    #[arg(env, long, default_value = "")]
+    pub group: String,
+
+    /// lat location
+    #[arg(env, long, default_value_t = 0.0)]
+    pub lat: f32,
+
+    /// lng location
+    #[arg(env, long, default_value_t = 0.0)]
+    pub lng: f32,
+}
+
+pub async fn run_gateway_server<C, CR, RPC, REQ, EMITTER>(http_port: u16, http_tls: bool, opts: GatewayArgs, ctx: MediaServerContext<()>, cluster: C, rpc_endpoint: RPC) -> Result<(), &'static str>
 where
     C: Cluster<CR> + Send + 'static,
     CR: ClusterEndpoint + Send + 'static,
@@ -89,8 +108,9 @@ where
 
     http_server.start(route, ctx.clone()).await;
     let mut tick = async_std::stream::interval(Duration::from_millis(100));
-    let mut gateway_logic = GatewayLogic::new();
+    let mut gateway_logic = GatewayLogic::new(opts.mode);
     let rpc_emitter = rpc_endpoint.emitter();
+    let mut gateway_feedback_tick = async_std::stream::interval(Duration::from_millis(2000));
 
     loop {
         let rpc = select! {
@@ -98,6 +118,13 @@ where
                 gateway_logic.on_tick(timer.now_ms());
                 continue;
             }
+            _ = gateway_feedback_tick.next().fuse() => {
+                if matches!(opts.mode, GatewayMode::Inner) {
+                    ping_global_gateway(&gateway_logic, &opts.group, (F32::<2>::new(opts.lat), F32::<2>::new(opts.lng)), node_id, &rpc_emitter);
+                }
+
+                continue;
+            },
             rpc = http_server.recv().fuse() => {
                 rpc.ok_or("HTTP_SERVER_ERROR")?
             },
@@ -200,4 +227,23 @@ where
             }
         }
     }
+}
+
+fn ping_global_gateway<EMITTER: RpcEmitter + Send + 'static>(logic: &GatewayLogic, group: &str, location: (F32<2>, F32<2>), node_id: NodeId, rpc_emitter: &EMITTER) {
+    let stats = logic.stats();
+    let req = NodePing {
+        node_id,
+        group: group.to_string(),
+        location: Some(location),
+        rtmp: stats.rtmp,
+        sip: stats.sip,
+        webrtc: stats.webrtc,
+    };
+
+    let rpc_emitter = rpc_emitter.clone();
+    async_std::task::spawn(async move {
+        if let Err(e) = rpc_emitter.request::<_, NodePong>(GLOBAL_GATEWAY_SERVICE, None, RPC_NODE_PING, req, 1000).await {
+            log::error!("[Gateway] ping global gateway error {:?}", e);
+        }
+    });
 }

--- a/servers/media-server/src/server/gateway/ip2location.rs
+++ b/servers/media-server/src/server/gateway/ip2location.rs
@@ -1,0 +1,31 @@
+use std::net::IpAddr;
+
+use maxminddb::Reader;
+use media_utils::F32;
+
+pub struct Ip2Location {
+    city_reader: Reader<Vec<u8>>,
+}
+
+impl Ip2Location {
+    pub fn new(database_city: &str) -> Self {
+        let city_reader = maxminddb::Reader::open_readfile(database_city).expect("Should open geoip database");
+        Self { city_reader }
+    }
+
+    pub fn get_location(&self, ip: &IpAddr) -> Option<(F32<2>, F32<2>)> {
+        match self.city_reader.lookup::<maxminddb::geoip2::City>(*ip) {
+            Ok(res) => {
+                let location = res.location?;
+                match (location.latitude, location.longitude) {
+                    (Some(lat), Some(lon)) => Some((F32::new(lat as f32), F32::new(lon as f32))),
+                    _ => None,
+                }
+            }
+            Err(err) => {
+                log::error!("cannot get location of ip {} {}", ip, err);
+                None
+            }
+        }
+    }
+}

--- a/servers/media-server/src/server/gateway/ip2location.rs
+++ b/servers/media-server/src/server/gateway/ip2location.rs
@@ -9,7 +9,7 @@ pub struct Ip2Location {
 
 impl Ip2Location {
     pub fn new(database_city: &str) -> Self {
-        let city_reader = maxminddb::Reader::open_readfile(database_city).expect("Should open geoip database");
+        let city_reader = maxminddb::Reader::open_readfile(database_city).expect("Failed to open geoip database");
         Self { city_reader }
     }
 

--- a/servers/media-server/src/server/gateway/logic/global_registry.rs
+++ b/servers/media-server/src/server/gateway/logic/global_registry.rs
@@ -254,6 +254,6 @@ mod tests {
     fn test_distance_function() {
         let from = (F32::<2>::new(0.0), F32::<2>::new(0.0));
         let to = (F32::<2>::new(1.0), F32::<2>::new(1.0));
-        assert_eq!(lat_lng_distance(&from, &to), 157.24939);
+        assert_eq!(F32::<2>::new(lat_lng_distance(&from, &to)), F32::<2>::new(157.24939));
     }
 }

--- a/servers/media-server/src/server/gateway/logic/global_registry.rs
+++ b/servers/media-server/src/server/gateway/logic/global_registry.rs
@@ -1,0 +1,259 @@
+use std::collections::HashMap;
+
+use cluster::{implement::NodeId, rpc::gateway::ServiceInfo};
+use media_utils::F32;
+use metrics::{describe_gauge, gauge};
+
+use super::{ServiceRegistry, ServiceType};
+
+const NODE_TIMEOUT_MS: u64 = 10_000;
+
+fn lat_lng_distance(from: &(F32<2>, F32<2>), to: &(F32<2>, F32<2>)) -> f32 {
+    let (from_lat, from_lng) = from;
+    let (to_lat, to_lng) = to;
+    let r = 6371.0; // radius of the earth in kilometers
+
+    let dlat = (from_lat.value() - to_lat.value()).to_radians();
+    let dlon = (from_lng.value() - to_lng.value()).to_radians();
+
+    let a = (dlat / 2.0).sin() * (dlat / 2.0).sin() + from_lat.value().to_radians().cos() * to_lat.value().to_radians().cos() * (dlon / 2.0).sin() * (dlon / 2.0).sin();
+    let c = 2.0 * ((a.sqrt()).atan2((1.0 - a).sqrt()));
+
+    r * c
+}
+
+#[derive(Debug, Default)]
+struct Zone {
+    location: (F32<2>, F32<2>),
+    nodes: HashMap<NodeId, u64>,
+    usage: u8,
+    live: u32,
+    max: u32,
+    last_updated: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct ServiceGlobalRegistry {
+    metric_live: String,
+    metric_max: String,
+    zones: HashMap<String, Zone>,
+}
+
+impl ServiceGlobalRegistry {
+    pub fn new(service: ServiceType) -> Self {
+        let metric_live = format!("gateway.sessions.{:?}.live", service);
+        let metric_max = format!("gateway.sessions.{:?}.max", service);
+        describe_gauge!(metric_live.clone(), format!("Current live {:?} sessions number", service));
+        describe_gauge!(metric_max.clone(), format!("Max live {:?} sessions number", service));
+
+        Self {
+            metric_live,
+            metric_max,
+            zones: Default::default(),
+        }
+    }
+
+    fn sum_live(&self) -> u32 {
+        self.zones.iter().map(|(_, s)| s.live).sum()
+    }
+
+    fn sum_max(&self) -> u32 {
+        self.zones.iter().map(|(_, s)| s.max).sum()
+    }
+}
+
+impl ServiceRegistry for ServiceGlobalRegistry {
+    /// remove not that dont received ping in NODE_TIMEOUT_MS
+    fn on_tick(&mut self, now_ms: u64) {
+        self.zones.retain(|_, s| s.last_updated + NODE_TIMEOUT_MS > now_ms);
+        for (_, zone) in self.zones.iter_mut() {
+            zone.nodes.retain(|_, &mut last_updated| last_updated + NODE_TIMEOUT_MS > now_ms);
+        }
+        gauge!(self.metric_live.clone(), self.sum_live() as f64);
+        gauge!(self.metric_max.clone(), self.sum_max() as f64);
+    }
+
+    /// we save node or create new, then sort by ascending order
+    fn on_ping(&mut self, now_ms: u64, group: &str, location: Option<(F32<2>, F32<2>)>, node_id: NodeId, usage: u8, live: u32, max: u32) {
+        let location = location.unwrap_or((F32::<2>::new(0.0), F32::<2>::new(0.0)));
+
+        if let Some(slot) = self.zones.get_mut(group) {
+            slot.nodes.insert(node_id, now_ms);
+            slot.usage = usage;
+            slot.live = live;
+            slot.max = max;
+            slot.last_updated = now_ms;
+        } else {
+            self.zones.insert(
+                group.to_string(),
+                Zone {
+                    nodes: HashMap::from([(node_id, now_ms)]),
+                    location,
+                    usage,
+                    live,
+                    max,
+                    last_updated: now_ms,
+                },
+            );
+        }
+    }
+
+    /// we get first with max_usage, if not enough => using max_usage_fallback
+    fn best_nodes(&mut self, location: Option<(F32<2>, F32<2>)>, _max_usage: u8, _max_usage_fallback: u8, size: usize) -> Vec<NodeId> {
+        let location = location.unwrap_or((F32::<2>::new(0.0), F32::<2>::new(0.0)));
+
+        //finding closest zone
+        let mut closest_zone = None;
+        let mut closest_distance = std::f32::MAX;
+        for (zone_name, zone) in self.zones.iter() {
+            let distance = lat_lng_distance(&location, &zone.location);
+            if distance < closest_distance {
+                closest_distance = distance;
+                closest_zone = Some(zone_name);
+            }
+        }
+
+        if let Some(zone) = closest_zone {
+            let zone = self.zones.get(zone).expect("Should has zone");
+            let mut nodes = zone.nodes.keys().cloned().collect::<Vec<_>>();
+            nodes.truncate(size);
+            nodes
+        } else {
+            vec![]
+        }
+    }
+
+    fn stats(&self) -> ServiceInfo {
+        panic!("dont support")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::gateway::logic::ServiceType;
+
+    // ServiceGlobalRegistry can be created with default values
+    #[test]
+    fn test_service_registry_creation() {
+        let registry = ServiceGlobalRegistry::new(ServiceType::Webrtc);
+        assert_eq!(registry.zones.len(), 0);
+    }
+
+    // test with single zone and single gateway
+    #[test]
+    fn test_service_registry_single_zone_single_gateway() {
+        let mut registry = ServiceGlobalRegistry::new(ServiceType::Webrtc);
+        let now_ms = 0;
+        let group = "group";
+        let location = Some((F32::<2>::new(0.0), F32::<2>::new(0.0)));
+        let node_id = 1;
+        let usage = 0;
+        let live = 0;
+        let max = 0;
+
+        registry.on_ping(now_ms, group, location, node_id, usage, live, max);
+        assert_eq!(registry.zones.len(), 1);
+        assert_eq!(registry.zones.get(group).unwrap().nodes.len(), 1);
+        assert_eq!(registry.zones.get(group).unwrap().nodes.get(&node_id).unwrap(), &now_ms);
+        assert_eq!(registry.zones.get(group).unwrap().usage, usage);
+        assert_eq!(registry.zones.get(group).unwrap().live, live);
+        assert_eq!(registry.zones.get(group).unwrap().max, max);
+        assert_eq!(registry.zones.get(group).unwrap().last_updated, now_ms);
+
+        assert_eq!(registry.best_nodes(location, 100, 100, 1), vec![node_id]);
+
+        registry.on_tick(now_ms + NODE_TIMEOUT_MS);
+        assert_eq!(registry.zones.len(), 0);
+    }
+
+    // test with single zone multi gateways
+    #[test]
+    fn test_service_registry_single_zone_multi_gateways() {
+        let mut registry = ServiceGlobalRegistry::new(ServiceType::Webrtc);
+        let now_ms = 0;
+        let group = "group";
+        let location = Some((F32::<2>::new(0.0), F32::<2>::new(0.0)));
+        let node_id_1 = 1;
+        let node_id_2 = 2;
+        let usage = 0;
+        let live = 0;
+        let max = 0;
+
+        registry.on_ping(now_ms, group, location, node_id_1, usage, live, max);
+        registry.on_ping(now_ms, group, location, node_id_2, usage, live, max);
+        assert_eq!(registry.zones.len(), 1);
+        assert_eq!(registry.zones.get(group).unwrap().nodes.len(), 2);
+        assert_eq!(registry.zones.get(group).unwrap().nodes.get(&node_id_1).unwrap(), &now_ms);
+        assert_eq!(registry.zones.get(group).unwrap().nodes.get(&node_id_2).unwrap(), &now_ms);
+        assert_eq!(registry.zones.get(group).unwrap().usage, usage);
+        assert_eq!(registry.zones.get(group).unwrap().live, live);
+        assert_eq!(registry.zones.get(group).unwrap().max, max);
+        assert_eq!(registry.zones.get(group).unwrap().last_updated, now_ms);
+
+        let mut best_nodes = registry.best_nodes(location, 100, 100, 2);
+        best_nodes.sort();
+        assert_eq!(best_nodes, vec![node_id_1, node_id_2]);
+
+        registry.on_ping(1000, group, location, node_id_1, usage, live, max);
+
+        //simulate timeout
+        registry.on_tick(now_ms + NODE_TIMEOUT_MS);
+        assert_eq!(registry.zones.len(), 1);
+        assert_eq!(registry.zones.get(group).unwrap().nodes.len(), 1);
+        assert_eq!(registry.zones.get(group).unwrap().nodes.get(&node_id_1).unwrap(), &1000);
+        assert_eq!(registry.zones.get(group).unwrap().usage, usage);
+        assert_eq!(registry.zones.get(group).unwrap().live, live);
+        assert_eq!(registry.zones.get(group).unwrap().max, max);
+        assert_eq!(registry.zones.get(group).unwrap().last_updated, 1000);
+    }
+
+    //test with multi zones and multi gateways
+    #[test]
+    fn test_service_registry_multi_zones_multi_gateways() {
+        let mut registry = ServiceGlobalRegistry::new(ServiceType::Webrtc);
+        let now_ms = 0;
+        let group_1 = "group_1";
+        let group_2 = "group_2";
+        let location_1 = Some((F32::<2>::new(0.0), F32::<2>::new(0.0)));
+        let location_2 = Some((F32::<2>::new(1.0), F32::<2>::new(1.0)));
+        let node_id_1 = 1;
+        let node_id_2 = 2;
+        let usage = 0;
+        let live = 0;
+        let max = 0;
+
+        registry.on_ping(now_ms, group_1, location_1, node_id_1, usage, live, max);
+        registry.on_ping(now_ms, group_2, location_2, node_id_2, usage, live, max);
+
+        assert_eq!(registry.zones.len(), 2);
+        assert_eq!(registry.zones.get(group_1).unwrap().nodes.len(), 1);
+        assert_eq!(registry.zones.get(group_1).unwrap().nodes.get(&node_id_1).unwrap(), &now_ms);
+        assert_eq!(registry.zones.get(group_1).unwrap().usage, usage);
+        assert_eq!(registry.zones.get(group_1).unwrap().live, live);
+        assert_eq!(registry.zones.get(group_1).unwrap().max, max);
+        assert_eq!(registry.zones.get(group_1).unwrap().last_updated, now_ms);
+
+        assert_eq!(registry.zones.get(group_2).unwrap().nodes.len(), 1);
+        assert_eq!(registry.zones.get(group_2).unwrap().nodes.get(&node_id_2).unwrap(), &now_ms);
+        assert_eq!(registry.zones.get(group_2).unwrap().usage, usage);
+        assert_eq!(registry.zones.get(group_2).unwrap().live, live);
+        assert_eq!(registry.zones.get(group_2).unwrap().max, max);
+        assert_eq!(registry.zones.get(group_2).unwrap().last_updated, now_ms);
+
+        let mut best_nodes = registry.best_nodes(location_1, 100, 100, 2);
+        best_nodes.sort();
+        assert_eq!(best_nodes, vec![node_id_1]);
+
+        let mut best_nodes = registry.best_nodes(location_2, 100, 100, 2);
+        best_nodes.sort();
+        assert_eq!(best_nodes, vec![node_id_2]);
+    }
+
+    #[test]
+    fn test_distance_function() {
+        let from = (F32::<2>::new(0.0), F32::<2>::new(0.0));
+        let to = (F32::<2>::new(1.0), F32::<2>::new(1.0));
+        assert_eq!(lat_lng_distance(&from, &to), 157.24939);
+    }
+}

--- a/servers/media-server/src/server/gateway/logic/inner_registry.rs
+++ b/servers/media-server/src/server/gateway/logic/inner_registry.rs
@@ -126,8 +126,15 @@ impl ServiceRegistry for ServiceInnerRegistry {
     }
 
     fn stats(&self) -> ServiceInfo {
+        let sum_max = self.sum_max();
+        let usage = if sum_max == 0 {
+            0
+        } else {
+            (self.sum_live() as f64 / sum_max as f64 * 100.0) as u8
+        };
+
         ServiceInfo {
-            usage: ((self.sum_live() * 100) / self.sum_max()) as u8,
+            usage,
             live: self.sum_live(),
             max: self.sum_max(),
             addr: None,
@@ -145,6 +152,16 @@ mod tests {
     #[test]
     fn test_service_registry_creation() {
         let registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
+        assert_eq!(
+            registry.stats(),
+            ServiceInfo {
+                usage: 0,
+                live: 0,
+                max: 0,
+                addr: None,
+                domain: None,
+            }
+        );
         assert_eq!(registry.nodes.len(), 0);
     }
 

--- a/servers/media-server/src/server/gateway/logic/inner_registry.rs
+++ b/servers/media-server/src/server/gateway/logic/inner_registry.rs
@@ -1,11 +1,12 @@
 use std::cmp::Ordering;
 
-use cluster::implement::NodeId;
+use cluster::{implement::NodeId, rpc::gateway::ServiceInfo};
+use media_utils::F32;
 use metrics::{describe_gauge, gauge};
 
-use super::ServiceType;
+use super::{ServiceRegistry, ServiceType};
 
-const NODE_TIMEOUT_MS: u64 = 5_000_000;
+const NODE_TIMEOUT_MS: u64 = 10_000;
 
 #[derive(Debug, Default)]
 struct NodeSlot {
@@ -40,13 +41,13 @@ impl Ord for NodeSlot {
 }
 
 #[derive(Debug)]
-pub(super) struct ServiceRegistry {
+pub(super) struct ServiceInnerRegistry {
     metric_live: String,
     metric_max: String,
     nodes: Vec<NodeSlot>,
 }
 
-impl ServiceRegistry {
+impl ServiceInnerRegistry {
     pub fn new(service: ServiceType) -> Self {
         let metric_live = format!("gateway.sessions.{:?}.live", service);
         let metric_max = format!("gateway.sessions.{:?}.max", service);
@@ -60,15 +61,25 @@ impl ServiceRegistry {
         }
     }
 
+    fn sum_live(&self) -> u32 {
+        self.nodes.iter().map(|s| s.live).sum()
+    }
+
+    fn sum_max(&self) -> u32 {
+        self.nodes.iter().map(|s| s.max).sum()
+    }
+}
+
+impl ServiceRegistry for ServiceInnerRegistry {
     /// remove not that dont received ping in NODE_TIMEOUT_MS
-    pub fn on_tick(&mut self, now_ms: u64) {
+    fn on_tick(&mut self, now_ms: u64) {
         self.nodes.retain(|s| s.last_updated + NODE_TIMEOUT_MS > now_ms);
         gauge!(self.metric_live.clone(), self.sum_live() as f64);
         gauge!(self.metric_max.clone(), self.sum_max() as f64);
     }
 
     /// we save node or create new, then sort by ascending order
-    pub fn on_ping(&mut self, now_ms: u64, node_id: NodeId, usage: u8, live: u32, max: u32) {
+    fn on_ping(&mut self, now_ms: u64, _group: &str, _location: Option<(F32<2>, F32<2>)>, node_id: NodeId, usage: u8, live: u32, max: u32) {
         if let Some(slot) = self.nodes.iter_mut().find(|s| s.node_id == node_id) {
             slot.usage = usage;
             slot.live = live;
@@ -87,7 +98,7 @@ impl ServiceRegistry {
     }
 
     /// we get first with max_usage, if not enough => using max_usage_fallback
-    pub fn best_nodes(&mut self, max_usage: u8, max_usage_fallback: u8, size: usize) -> Vec<NodeId> {
+    fn best_nodes(&mut self, _location: Option<(F32<2>, F32<2>)>, max_usage: u8, max_usage_fallback: u8, size: usize) -> Vec<NodeId> {
         let mut res = vec![];
         for slot in self.nodes.iter().rev() {
             if slot.usage <= max_usage {
@@ -114,40 +125,40 @@ impl ServiceRegistry {
         res
     }
 
-    fn sum_live(&self) -> u32 {
-        self.nodes.iter().map(|s| s.live).sum()
-    }
-
-    fn sum_max(&self) -> u32 {
-        self.nodes.iter().map(|s| s.max).sum()
+    fn stats(&self) -> ServiceInfo {
+        ServiceInfo {
+            usage: ((self.sum_live() * 100) / self.sum_max()) as u8,
+            live: self.sum_live(),
+            max: self.sum_max(),
+            addr: None,
+            domain: None,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::server::gateway::logic::{
-        service::{ServiceRegistry, NODE_TIMEOUT_MS},
-        ServiceType,
-    };
+    use super::*;
+    use crate::server::gateway::logic::ServiceType;
 
-    // ServiceRegistry can be created with default values
+    // ServiceInnerRegistry can be created with default values
     #[test]
     fn test_service_registry_creation() {
-        let registry = ServiceRegistry::new(ServiceType::Webrtc);
+        let registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
         assert_eq!(registry.nodes.len(), 0);
     }
 
     // on_ping adds a new node to the registry
     #[test]
     fn test_on_ping_adds_new_node() {
-        let mut registry = ServiceRegistry::new(ServiceType::Webrtc);
+        let mut registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
         let now_ms = 0;
         let node_id = 1;
         let live = 50;
         let usage = 50;
         let max = 100;
 
-        registry.on_ping(now_ms, node_id, usage, live, max);
+        registry.on_ping(now_ms, "", None, node_id, usage, live, max);
 
         assert_eq!(registry.nodes.len(), 1);
         assert_eq!(registry.nodes[0].node_id, node_id);
@@ -163,20 +174,20 @@ mod tests {
     // on_ping updates an existing node in the registry
     #[test]
     fn test_on_ping_updates_existing_node() {
-        let mut registry = ServiceRegistry::new(ServiceType::Webrtc);
+        let mut registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
         let now_ms = 0;
         let node_id = 1;
         let live = 50;
         let usage = 50;
         let max = 100;
 
-        registry.on_ping(now_ms, node_id, usage, live, max);
+        registry.on_ping(now_ms, "", None, node_id, usage, live, max);
 
         let new_usage = 75;
         let new_live = 112;
         let new_max = 150;
 
-        registry.on_ping(now_ms + 1000, node_id, new_usage, new_live, new_max);
+        registry.on_ping(now_ms + 1000, "", None, node_id, new_usage, new_live, new_max);
 
         assert_eq!(registry.nodes.len(), 1);
         assert_eq!(registry.nodes[0].node_id, node_id);
@@ -189,19 +200,19 @@ mod tests {
     // on_tick removes all nodes when all nodes haven't received a ping in NODE_TIMEOUT_MS
     #[test]
     fn test_on_tick_removes_all_nodes() {
-        let mut registry = ServiceRegistry::new(ServiceType::Webrtc);
+        let mut registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
         let now_ms = 0;
         let node_id1 = 1;
         let live1 = 50;
         let usage1 = 50;
         let max1 = 100;
-        registry.on_ping(now_ms, node_id1, usage1, live1, max1);
+        registry.on_ping(now_ms, "", None, node_id1, usage1, live1, max1);
 
         let node_id2 = 2;
         let live2 = 112;
         let usage2 = 75;
         let max2 = 150;
-        registry.on_ping(now_ms, node_id2, usage2, live2, max2);
+        registry.on_ping(now_ms, "", None, node_id2, usage2, live2, max2);
 
         registry.on_tick(now_ms + NODE_TIMEOUT_MS + 1);
 
@@ -210,19 +221,19 @@ mod tests {
 
     #[test]
     fn test_best_nodes_returns_nodes_with_max_usage() {
-        let mut registry = ServiceRegistry::new(ServiceType::Webrtc);
+        let mut registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
         let now_ms = 0;
         let node_id1 = 1;
         let live1 = 50;
         let usage1 = 50;
         let max1 = 100;
-        registry.on_ping(now_ms, node_id1, usage1, live1, max1);
+        registry.on_ping(now_ms, "", None, node_id1, usage1, live1, max1);
 
         let node_id2 = 2;
         let usage2 = 75;
         let live2 = 112;
         let max2 = 150;
-        registry.on_ping(now_ms, node_id2, usage2, live2, max2);
+        registry.on_ping(now_ms, "", None, node_id2, usage2, live2, max2);
 
         assert_eq!(registry.sum_live(), live1 + live2);
         assert_eq!(registry.sum_max(), max1 + max2);
@@ -231,7 +242,7 @@ mod tests {
         let max_usage_fallback = 70;
         let size = 2;
 
-        let result = registry.best_nodes(max_usage, max_usage_fallback, size);
+        let result = registry.best_nodes(None, max_usage, max_usage_fallback, size);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], node_id1);
@@ -239,28 +250,53 @@ mod tests {
 
     #[test]
     fn test_best_nodes_returns_nodes_with_max_usage_fallback() {
-        let mut registry = ServiceRegistry::new(ServiceType::Webrtc);
+        let mut registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
         let now_ms = 0;
         let node_id1 = 1;
         let usage1 = 50;
         let live1 = 50;
         let max1 = 100;
-        registry.on_ping(now_ms, node_id1, usage1, live1, max1);
+        registry.on_ping(now_ms, "", None, node_id1, usage1, live1, max1);
 
         let node_id2 = 2;
         let usage2 = 75;
         let live2 = 112;
         let max2 = 150;
-        registry.on_ping(now_ms, node_id2, usage2, live2, max2);
+        registry.on_ping(now_ms, "", None, node_id2, usage2, live2, max2);
 
         let max_usage = 60;
         let max_usage_fallback = 80;
         let size = 2;
 
-        let mut result = registry.best_nodes(max_usage_fallback, max_usage, size);
+        let mut result = registry.best_nodes(None, max_usage_fallback, max_usage, size);
 
         assert_eq!(result.len(), 2);
         result.sort();
         assert_eq!(result, [node_id1, node_id2]);
+    }
+
+    #[test]
+    fn test_stats() {
+        let mut registry = ServiceInnerRegistry::new(ServiceType::Webrtc);
+        let now_ms = 0;
+        let node_id1 = 1;
+        let usage1 = 50;
+        let live1 = 50;
+        let max1 = 100;
+        registry.on_ping(now_ms, "", None, node_id1, usage1, live1, max1);
+
+        let node_id2 = 2;
+        let usage2 = 100;
+        let live2 = 100;
+        let max2 = 200;
+        registry.on_ping(now_ms, "", None, node_id2, usage2, live2, max2);
+
+        let stats = registry.stats();
+
+        assert_eq!(stats.usage, 50);
+        assert_eq!(stats.live, 150);
+        assert_eq!(stats.max, 300);
+        assert_eq!(stats.addr, None);
+        assert_eq!(stats.domain, None);
     }
 }

--- a/servers/media-server/src/server/gateway/rpc.rs
+++ b/servers/media-server/src/server/gateway/rpc.rs
@@ -1,4 +1,4 @@
-use ::cluster::rpc::gateway::{NodePing, NodePong};
+use ::cluster::rpc::gateway::{NodePing, NodePong, QueryBestNodesRequest, QueryBestNodesResponse};
 use ::cluster::rpc::{general::*, webrtc::*, whep::*, whip::*, RpcReqRes};
 
 pub mod cluster;
@@ -6,6 +6,7 @@ pub mod http;
 
 pub enum RpcEvent {
     NodePing(Box<dyn RpcReqRes<NodePing, NodePong>>),
+    BestNodest(Box<dyn RpcReqRes<QueryBestNodesRequest, QueryBestNodesResponse>>),
     WhipConnect(Box<dyn RpcReqRes<WhipConnectRequest, WhipConnectResponse>>),
     WhepConnect(Box<dyn RpcReqRes<WhepConnectRequest, WhepConnectResponse>>),
     WebrtcConnect(Box<dyn RpcReqRes<WebrtcConnectRequest, WebrtcConnectResponse>>),

--- a/servers/media-server/src/server/gateway/rpc.rs
+++ b/servers/media-server/src/server/gateway/rpc.rs
@@ -6,9 +6,9 @@ pub mod http;
 
 pub enum RpcEvent {
     NodePing(Box<dyn RpcReqRes<NodePing, NodePong>>),
-    WhipConnect(Box<dyn RpcReqRes<WhipConnectRequest, WhipConnectResponse> + Sync>),
-    WhepConnect(Box<dyn RpcReqRes<WhepConnectRequest, WhepConnectResponse> + Sync>),
-    WebrtcConnect(Box<dyn RpcReqRes<WebrtcConnectRequest, WebrtcConnectResponse> + Sync>),
+    WhipConnect(Box<dyn RpcReqRes<WhipConnectRequest, WhipConnectResponse>>),
+    WhepConnect(Box<dyn RpcReqRes<WhepConnectRequest, WhepConnectResponse>>),
+    WebrtcConnect(Box<dyn RpcReqRes<WebrtcConnectRequest, WebrtcConnectResponse>>),
     WebrtcRemoteIce(Box<dyn RpcReqRes<WebrtcRemoteIceRequest, WebrtcRemoteIceResponse>>),
     WebrtcSdpPatch(Box<dyn RpcReqRes<WebrtcPatchRequest, WebrtcPatchResponse>>),
     MediaEndpointClose(Box<dyn RpcReqRes<MediaEndpointCloseRequest, MediaEndpointCloseResponse>>),

--- a/servers/media-server/src/server/gateway/rpc/cluster.rs
+++ b/servers/media-server/src/server/gateway/rpc/cluster.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use cluster::rpc::{
     gateway::{NodeHealthcheckRequest, NodeHealthcheckResponse},
-    RpcEmitter, RpcEndpoint, RpcRequest, RPC_NODE_HEALTHCHECK, RPC_NODE_PING,
+    RpcEmitter, RpcEndpoint, RpcRequest, RPC_MEDIA_ENDPOINT_CLOSE, RPC_NODE_HEALTHCHECK, RPC_NODE_PING, RPC_WEBRTC_CONNECT, RPC_WEBRTC_ICE, RPC_WEBRTC_PATCH, RPC_WHEP_CONNECT, RPC_WHIP_CONNECT,
 };
 
 use super::RpcEvent;
@@ -33,6 +33,38 @@ impl<RPC: RpcEndpoint<Req, Emitter>, Req: RpcRequest, Emitter: RpcEmitter> Gatew
                 RPC_NODE_PING => {
                     if let Some(req) = event.parse() {
                         return Some(RpcEvent::NodePing(req));
+                    }
+                }
+                RPC_WEBRTC_CONNECT => {
+                    if let Some(req) = event.parse() {
+                        return Some(RpcEvent::WebrtcConnect(req));
+                    }
+                }
+                RPC_WEBRTC_ICE => {
+                    if let Some(req) = event.parse() {
+                        return Some(RpcEvent::WebrtcRemoteIce(req));
+                    }
+                }
+                RPC_WEBRTC_PATCH => {
+                    if let Some(req) = event.parse() {
+                        return Some(RpcEvent::WebrtcSdpPatch(req));
+                    }
+                }
+                RPC_MEDIA_ENDPOINT_CLOSE => {
+                    if let Some(req) = event.parse() {
+                        return Some(RpcEvent::MediaEndpointClose(req));
+                    }
+                }
+                RPC_WHIP_CONNECT => {
+                    log::info!("[MediaServer][Webrtc] on whip connect request");
+                    if let Some(req) = event.parse() {
+                        return Some(RpcEvent::WhipConnect(req));
+                    }
+                }
+                RPC_WHEP_CONNECT => {
+                    log::info!("[MediaServer][Webrtc] on whep connect request");
+                    if let Some(req) = event.parse() {
+                        return Some(RpcEvent::WhepConnect(req));
                     }
                 }
                 _ => {

--- a/servers/media-server/src/server/gateway/rpc/http.rs
+++ b/servers/media-server/src/server/gateway/rpc/http.rs
@@ -238,8 +238,8 @@ impl GatewayHttpApis {
             body.0.compressed_sdp = Some(string_zip.compress(&sdp));
         }
         body.0.session_uuid = Some(data.1.generate_session_uuid());
-        body.0.ip_addr = Some(ip_addr);
-        body.0.user_agent = Some(user_agent);
+        body.0.ip_addr = ip_addr;
+        body.0.user_agent = user_agent;
 
         if body.0.verify(data.1.verifier().deref()).is_none() {
             return Ok(Json(Response {

--- a/servers/media-server/src/server/gateway/webrtc_route.rs
+++ b/servers/media-server/src/server/gateway/webrtc_route.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{net::IpAddr, sync::Arc};
 
 use cluster::{
     implement::NodeId,
@@ -89,7 +89,8 @@ pub fn route_to_node<EMITTER, Req, Res>(
     gateway_node_id: NodeId,
     service: ServiceType,
     cmd: &'static str,
-    ip: &str,
+    ip: IpAddr,
+    location: Option<(F32<2>, F32<2>)>,
     version: &Option<String>,
     user_agent: &str,
     session_uuid: u64,
@@ -105,9 +106,8 @@ pub fn route_to_node<EMITTER, Req, Res>(
         user_agent: user_agent.to_string(),
         gateway_node_id,
     });
-    emit_endpoint_event(&emitter, &timer, session_uuid, ip, version, event);
+    emit_endpoint_event(&emitter, &timer, session_uuid, &ip.to_string(), version, event);
 
-    let location = Some((F32::<2>::new(0.0), F32::<2>::new(0.0)));
     let nodes = gateway_logic.best_nodes(location, service, 60, 80, 3);
     if !nodes.is_empty() {
         let rpc_emitter = emitter.clone();
@@ -157,7 +157,7 @@ pub fn route_to_node<EMITTER, Req, Res>(
             media_node_ids: vec![],
         });
 
-        emit_endpoint_event(&emitter, &timer, session_uuid, ip, version, event);
+        emit_endpoint_event(&emitter, &timer, session_uuid, &ip.to_string(), version, event);
 
         log::warn!("[Gateway] webrtc connect but media-server pool empty");
         req.answer(Err("NODE_POOL_EMPTY"));

--- a/servers/media-server/src/server/rtmp.rs
+++ b/servers/media-server/src/server/rtmp.rs
@@ -80,7 +80,7 @@ where
     let mut rpc_endpoint = RtmpClusterRpc::new(rpc_endpoint);
     let mut http_server: HttpRpcServer<RpcEvent> = crate::rpc::http::HttpRpcServer::new(http_port, http_tls);
 
-    let api_service = OpenApiService::new(RtmpHttpApis, "Rtmp Server", "1.0.0").server("http://localhost:3000");
+    let api_service = OpenApiService::new(RtmpHttpApis, "Rtmp Server", env!("CARGO_PKG_VERSION")).server("/");
     let ui = api_service.swagger_ui();
     let spec = api_service.spec();
     let node_info = NodeInfo {

--- a/servers/media-server/src/server/rtmp.rs
+++ b/servers/media-server/src/server/rtmp.rs
@@ -3,9 +3,10 @@ use std::{
     time::Duration,
 };
 
-use async_std::{channel::Sender, prelude::FutureExt as _};
+use async_std::{channel::Sender, prelude::FutureExt as _, stream::StreamExt};
 use clap::Parser;
 use cluster::{
+    implement::NodeId,
     rpc::{
         gateway::{NodePing, NodePong, ServiceInfo},
         general::{MediaEndpointCloseResponse, MediaSessionProtocol, NodeInfo, ServerType},
@@ -14,7 +15,7 @@ use cluster::{
     Cluster, ClusterEndpoint, INNER_GATEWAY_SERVICE,
 };
 use futures::{select, FutureExt};
-use media_utils::{AutoCancelTask, ErrorDebugger};
+use media_utils::ErrorDebugger;
 use metrics_dashboard::build_dashboard_route;
 use poem::{web::Json, Route};
 use poem_openapi::OpenApiService;
@@ -108,42 +109,14 @@ where
     let rtmp_port = opts.port;
     let node_id = cluster.node_id();
     let rpc_emitter = rpc_endpoint.emitter();
-    let ctx_c = ctx.clone();
-    let _ping_task: AutoCancelTask<_> = async_std::task::spawn_local(async move {
-        async_std::task::sleep(Duration::from_secs(10)).await;
-        loop {
-            if let Err(e) = rpc_emitter
-                .request::<_, NodePong>(
-                    INNER_GATEWAY_SERVICE,
-                    None,
-                    RPC_NODE_PING,
-                    NodePing {
-                        node_id,
-                        rtmp: None,
-                        sip: Some(ServiceInfo {
-                            usage: ((ctx_c.conns_live() * 100) / ctx_c.conns_max()) as u8,
-                            live: ctx_c.conns_live() as u32,
-                            max: ctx_c.conns_max() as u32,
-                            addr: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rtmp_port)),
-                            domain: None,
-                        }),
-                        webrtc: None,
-                    },
-                    5000,
-                )
-                .await
-            {
-                log::error!("[RtmpMediaServer] ping gateway error {:?}", e);
-            } else {
-                log::info!("[RtmpMediaServer] ping gateway success");
-            }
-            async_std::task::sleep(Duration::from_secs(1)).await;
-        }
-    })
-    .into();
+    let mut gateway_feedback_tick = async_std::stream::interval(Duration::from_millis(2000));
 
     loop {
         let rpc = select! {
+            _ = gateway_feedback_tick.next().fuse() => {
+                ping_gateway(&ctx, node_id, rtmp_port, &rpc_emitter);
+                continue;
+            },
             rpc = http_server.recv().fuse() => {
                 rpc.ok_or("HTTP_SERVER_ERROR")?
             },
@@ -208,4 +181,28 @@ where
             }
         }
     }
+}
+
+fn ping_gateway<EMITTER: RpcEmitter + Send + 'static>(ctx: &MediaServerContext<InternalControl>, node_id: NodeId, rtmp_port: u16, rpc_emitter: &EMITTER) {
+    let req = NodePing {
+        node_id,
+        group: "".to_string(),
+        location: None,
+        rtmp: Some(ServiceInfo {
+            usage: ((ctx.conns_live() * 100) / ctx.conns_max()) as u8,
+            live: ctx.conns_live() as u32,
+            max: ctx.conns_max() as u32,
+            addr: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rtmp_port)),
+            domain: None,
+        }),
+        sip: None,
+        webrtc: None,
+    };
+
+    let rpc_emitter = rpc_emitter.clone();
+    async_std::task::spawn(async move {
+        if let Err(e) = rpc_emitter.request::<_, NodePong>(INNER_GATEWAY_SERVICE, None, RPC_NODE_PING, req, 1000).await {
+            log::error!("[RtmpServer] ping gateway error {:?}", e);
+        }
+    });
 }

--- a/servers/media-server/src/server/sip.rs
+++ b/servers/media-server/src/server/sip.rs
@@ -64,7 +64,7 @@ where
     let rpc_endpoint = SipClusterRpc::new(rpc_endpoint);
     let mut http_server: HttpRpcServer<RpcEvent> = crate::rpc::http::HttpRpcServer::new(http_port, http_tls);
 
-    let api_service = OpenApiService::new(SipHttpApis, "Sip Server", "1.0.0").server("/");
+    let api_service = OpenApiService::new(SipHttpApis, "Sip Server", env!("CARGO_PKG_VERSION")).server("/");
     let ui = api_service.swagger_ui();
     let spec = api_service.spec();
     let node_info = NodeInfo {

--- a/servers/media-server/src/server/token_generate.rs
+++ b/servers/media-server/src/server/token_generate.rs
@@ -19,7 +19,7 @@ pub struct TokenGenerateArgs {}
 
 pub async fn run_token_generate_server(http_port: u16, http_tls: bool, _opts: TokenGenerateArgs, secret: &str, token_signer: Arc<dyn SessionTokenSigner + Send + Sync>) -> Result<(), &'static str> {
     let mut http_server: HttpRpcServer<()> = crate::rpc::http::HttpRpcServer::new(http_port, http_tls);
-    let api_service = OpenApiService::new(TokenGenerateHttpApis, "Token Generate Server", "1.0.0").server("/");
+    let api_service = OpenApiService::new(TokenGenerateHttpApis, "Token Generate Server", env!("CARGO_PKG_VERSION")).server("/");
     let ui = api_service.swagger_ui();
     let spec = api_service.spec();
 

--- a/servers/media-server/src/server/webrtc.rs
+++ b/servers/media-server/src/server/webrtc.rs
@@ -88,7 +88,7 @@ where
         address: format!("{}", cluster.node_addr()),
         server_type: ServerType::WEBRTC,
     };
-    let api_service = OpenApiService::new(WebrtcHttpApis, "Webrtc Server", "1.0.0").server("/");
+    let api_service = OpenApiService::new(WebrtcHttpApis, "Webrtc Server", env!("CARGO_PKG_VERSION")).server("/");
     let ui = api_service.swagger_ui();
     let spec = api_service.spec();
 

--- a/servers/media-server/src/server/webrtc.rs
+++ b/servers/media-server/src/server/webrtc.rs
@@ -1,8 +1,9 @@
 use std::{ops::Deref, time::Duration};
 
-use async_std::{channel::Sender, prelude::FutureExt as _};
+use async_std::{channel::Sender, prelude::FutureExt as _, stream::StreamExt};
 use clap::Parser;
 use cluster::{
+    implement::NodeId,
     rpc::{
         gateway::{NodePing, NodePong, ServiceInfo},
         general::{MediaEndpointCloseResponse, MediaSessionProtocol, NodeInfo, ServerType},
@@ -14,7 +15,7 @@ use cluster::{
     BitrateControlMode, Cluster, ClusterEndpoint, ClusterEndpointPublishScope, ClusterEndpointSubscribeScope, MixMinusAudioMode, VerifyObject, INNER_GATEWAY_SERVICE,
 };
 use futures::{select, FutureExt};
-use media_utils::{AutoCancelTask, ErrorDebugger, StringCompression, SystemTimer, Timer};
+use media_utils::{ErrorDebugger, StringCompression, SystemTimer, Timer};
 use metrics_dashboard::build_dashboard_route;
 use poem::{web::Json, Route};
 use poem_openapi::OpenApiService;
@@ -111,42 +112,14 @@ where
 
     let node_id = cluster.node_id();
     let rpc_emitter = rpc_endpoint.emitter();
-    let ctx_c = ctx.clone();
-    let _ping_task: AutoCancelTask<_> = async_std::task::spawn_local(async move {
-        async_std::task::sleep(Duration::from_secs(10)).await;
-        loop {
-            if let Err(e) = rpc_emitter
-                .request::<_, NodePong>(
-                    INNER_GATEWAY_SERVICE,
-                    None,
-                    RPC_NODE_PING,
-                    NodePing {
-                        node_id,
-                        rtmp: None,
-                        sip: None,
-                        webrtc: Some(ServiceInfo {
-                            usage: ((ctx_c.conns_live() * 100) / ctx_c.conns_max()) as u8,
-                            live: ctx_c.conns_live() as u32,
-                            max: ctx_c.conns_max() as u32,
-                            addr: None,
-                            domain: None,
-                        }),
-                    },
-                    5000,
-                )
-                .await
-            {
-                log::error!("[WebrtcMediaServer] ping gateway error {:?}", e);
-            } else {
-                log::info!("[WebrtcMediaServer] ping gateway success");
-            }
-            async_std::task::sleep(Duration::from_secs(1)).await;
-        }
-    })
-    .into();
+    let mut gateway_feedback_tick = async_std::stream::interval(Duration::from_millis(2000));
 
     loop {
         let rpc = select! {
+            _ = gateway_feedback_tick.next().fuse() => {
+                ping_gateway(&ctx, node_id, &rpc_emitter);
+                continue;
+            },
             rpc = http_server.recv().fuse() => {
                 rpc.ok_or("HTTP_SERVER_ERROR")?
             },
@@ -407,4 +380,28 @@ where
             }
         }
     }
+}
+
+fn ping_gateway<EMITTER: RpcEmitter + Send + 'static>(ctx: &MediaServerContext<InternalControl>, node_id: NodeId, rpc_emitter: &EMITTER) {
+    let req = NodePing {
+        node_id,
+        group: "".to_string(),
+        location: None,
+        rtmp: None,
+        sip: None,
+        webrtc: Some(ServiceInfo {
+            usage: ((ctx.conns_live() * 100) / ctx.conns_max()) as u8,
+            live: ctx.conns_live() as u32,
+            max: ctx.conns_max() as u32,
+            addr: None,
+            domain: None,
+        }),
+    };
+
+    let rpc_emitter = rpc_emitter.clone();
+    async_std::task::spawn(async move {
+        if let Err(e) = rpc_emitter.request::<_, NodePong>(INNER_GATEWAY_SERVICE, None, RPC_NODE_PING, req, 1000).await {
+            log::error!("[WebrtcServer] ping gateway error {:?}", e);
+        }
+    });
 }

--- a/servers/media-server/src/server/webrtc/rpc/http.rs
+++ b/servers/media-server/src/server/webrtc/rpc/http.rs
@@ -264,8 +264,8 @@ impl WebrtcHttpApis {
 
         log::info!("[HttpApis] create Webrtc endpoint {}/{}", body.0.room, body.0.peer);
         body.0.session_uuid = Some(data.1.generate_session_uuid());
-        body.0.ip_addr = Some(ip_addr);
-        body.0.user_agent = Some(user_agent);
+        body.0.ip_addr = ip_addr;
+        body.0.user_agent = user_agent;
 
         let (req, rx) = RpcReqResHttp::<WebrtcConnectRequest, WebrtcConnectResponse>::new(body.0);
         data.0


### PR DESCRIPTION
This PR add global gateway mode, which are used to route user connect request to closest zone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Gateway Server documentation explaining zone-level and global gateways.
  - Added a script to download GeoLite2-City.mmdb for geo-IP location determination.
  - Implemented new Gateway Modes for media servers to optimize request routing.
  - Developed `Ip2Location` functionality to retrieve geographical locations from IP addresses.
  - Added `GatewayStats` to provide service node statistics.
  - Expanded gateway logic to manage service nodes and statistics across zones.
  - Introduced new RPC commands for WebRTC and media endpoint management.

- **Improvements**
  - Enhanced node ping functionality with additional information.
  - Improved IP address handling by switching from strings to `IpAddr` type in RPC structures.
  - Streamlined HTTP request processing for WebRTC connections.
  
- **Refactor**
  - Removed unnecessary trait bounds from RPC trait objects.
  - Adjusted gateway server logic to utilize new `GatewayMode` enum.

- **Bug Fixes**
  - Fixed `.gitignore` to properly exclude specific directories and files.

- **Documentation**
  - Updated server gateway documentation to reflect new features and logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->