### PR TITLE
fix: some sdk http apis enum between serde and poem-openapi

### DIFF
--- a/packages/cluster/src/define/endpoint.rs
+++ b/packages/cluster/src/define/endpoint.rs
@@ -26,6 +26,7 @@ pub enum ClusterStateEndpointState {
 pub enum ClusterEndpointSubscribeScope {
     Full,
     #[serde(rename = "stream_only")]
+    #[oai(rename = "stream_only")]
     StreamOnly,
     Manual,
 }
@@ -53,6 +54,8 @@ impl Default for ClusterEndpointSubscribeScope {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Copy, Clone, Enum)]
 pub enum ClusterEndpointPublishScope {
     Full,
+    #[serde(rename = "stream_only")]
+    #[oai(rename = "stream_only")]
     StreamOnly,
 }
 

--- a/packages/media-utils/src/req_res.rs
+++ b/packages/media-utils/src/req_res.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 pub struct Response<T: ParseFromJSON + ToJSON + Type + Send + Sync> {
     pub status: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[oai(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[oai(skip_serializing_if = "Option::is_none")]
     pub data: Option<T>,
 }

--- a/packages/transport/src/kind.rs
+++ b/packages/transport/src/kind.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Hash, Enum)]
 pub enum MediaKind {
     #[serde(rename = "audio")]
+    #[oai(rename = "audio")]
     Audio,
     #[serde(rename = "video")]
+    #[oai(rename = "video")]
     Video,
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced API documentation and serialization compatibility for cluster endpoints and media types, improving integration with OpenAPI tools.
	- Improved response structure for media utilities, ensuring more precise API documentation and client-side handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->