### PR TITLE
chore: config release name to v{{ version }} style

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -4,6 +4,8 @@ git_release_enable = false
 [[package]]
 name = "atm0s-media-server"
 git_release_enable = true
+git_release_name = "v{{ version }}"
+git_tag_name = "v{{ version }}"
 changelog_include = [
     "atm0s-media-server-audio-mixer",
     "atm0s-media-server-cluster",


### PR DESCRIPTION
## Pull Request

### Description

This PR setting release-plz config for setting release name and tag name as "v{{ version }}" style

### Related Issue

No

### Checklist
- [ ] I have tested the changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added appropriate tests, if applicable.