### PR TITLE
Fix: rpc HTTP bad request response with more info

### DIFF
--- a/servers/media-server/src/server/gateway/rpc/http.rs
+++ b/servers/media-server/src/server/gateway/rpc/http.rs
@@ -95,7 +95,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         let sdp = match (res.sdp, res.compressed_sdp) {
             (Some(sdp), _) => Ok(sdp),
             (_, Some(compressed_sdp)) => string_zip.uncompress(&compressed_sdp).ok_or(poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR)),
@@ -119,7 +119,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         if let Some(sdp) = res.ice_restart_sdp {
             log::info!("[HttpApis] Whip endpoint patch with ice_restart");
             Ok(HttpResponse::new(ApplicationSdpPatch(sdp)))
@@ -145,7 +145,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let _res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let _res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         log::info!("[HttpApis] Whip endpoint closed conn {}", conn_id.0);
         Ok(Json(Response {
             status: true,
@@ -181,7 +181,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         let sdp = match (res.sdp, res.compressed_sdp) {
             (Some(sdp), _) => Ok(sdp),
             (_, Some(compressed_sdp)) => string_zip.uncompress(&compressed_sdp).ok_or(poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR)),
@@ -205,7 +205,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         if let Some(sdp) = res.ice_restart_sdp {
             log::info!("[HttpApis] Whep endpoint patch with ice_restart");
             Ok(HttpResponse::new(ApplicationSdpPatch(sdp)))
@@ -231,7 +231,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let _res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let _res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         log::info!("[HttpApis] Whep endpoint closed conn {}", conn_id.0);
         Ok(Json(Response {
             status: true,
@@ -272,7 +272,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         let sdp = match (res.sdp, res.compressed_sdp) {
             (Some(sdp), _) => Ok(sdp),
             (_, Some(compressed_sdp)) => string_zip.uncompress(&compressed_sdp).ok_or(poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR)),
@@ -300,7 +300,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         Ok(Json(Response {
             status: true,
             error: None,
@@ -318,7 +318,7 @@ impl GatewayHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let _res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let _res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         log::info!("[HttpApis] Webrtc endpoint closed conn {}", conn_id.0);
         Ok(Json(Response {
             status: true,

--- a/servers/media-server/src/server/rtmp/rpc/http.rs
+++ b/servers/media-server/src/server/rtmp/rpc/http.rs
@@ -38,7 +38,7 @@ impl RtmpHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let _res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let _res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         log::info!("[HttpApis] Rtmp endpoint closed conn {}", conn_id.0);
         Ok(Json(Response {
             status: true,

--- a/servers/media-server/src/server/sip/rpc/http.rs
+++ b/servers/media-server/src/server/sip/rpc/http.rs
@@ -58,7 +58,7 @@ impl SipHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         Ok(Json(Response {
             status: true,
             error: None,

--- a/servers/media-server/src/server/webrtc/rpc/http.rs
+++ b/servers/media-server/src/server/webrtc/rpc/http.rs
@@ -78,7 +78,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         let sdp = match (res.sdp, res.compressed_sdp) {
             (Some(sdp), _) => Ok(sdp),
             (_, Some(compressed_sdp)) => StringCompression::default()
@@ -104,7 +104,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         if let Some(sdp) = res.ice_restart_sdp {
             log::info!("[HttpApis] Whip endpoint patch with ice_restart");
             Ok(HttpResponse::new(ApplicationSdpPatch(sdp)))
@@ -130,7 +130,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let _res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let _res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         log::info!("[HttpApis] Whip endpoint closed conn {}", conn_id.0);
         Ok(Json(Response {
             status: true,
@@ -172,7 +172,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         let sdp = match (res.sdp, res.compressed_sdp) {
             (Some(sdp), _) => Ok(sdp),
             (_, Some(compressed_sdp)) => StringCompression::default()
@@ -198,7 +198,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         if let Some(sdp) = res.ice_restart_sdp {
             log::info!("[HttpApis] Whep endpoint patch with ice_restart");
             Ok(HttpResponse::new(ApplicationSdpPatch(sdp)))
@@ -224,7 +224,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let _res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let _res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         log::info!("[HttpApis] Whep endpoint closed conn {}", conn_id.0);
         Ok(Json(Response {
             status: true,
@@ -273,7 +273,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         let sdp = match (res.sdp, res.compressed_sdp) {
             (Some(sdp), _) => Ok(sdp),
             (_, Some(compressed_sdp)) => StringCompression::default()
@@ -304,7 +304,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         Ok(Json(Response {
             status: true,
             error: None,
@@ -322,7 +322,7 @@ impl WebrtcHttpApis {
             .await
             .map_err(|_e| poem::Error::from_status(StatusCode::INTERNAL_SERVER_ERROR))?;
         let res = rx.recv().await.map_err(|e| poem::Error::new(e, StatusCode::INTERNAL_SERVER_ERROR))?;
-        let _res = res.map_err(|_e| poem::Error::from_status(StatusCode::BAD_REQUEST))?;
+        let _res = res.map_err(|e| poem::Error::from_string(e, StatusCode::BAD_REQUEST))?;
         log::info!("[HttpApis] Webrtc endpoint closed conn {}", conn_id.0);
         Ok(Json(Response {
             status: true,


### PR DESCRIPTION
## Pull Request

### Description

This PR updates servers HTTP Rpc Error Handling. Now, for Bad Request, server will provide an error reason in the body instead of just an error status.

### Related Issue
#215 

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling across various server components for more informative responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->