### PR TITLE
feat: add cluster metadata publish and subscribe options: peer and track info

### DIFF
--- a/packages/media_core/src/cluster.rs
+++ b/packages/media_core/src/cluster.rs
@@ -15,7 +15,7 @@ use std::{
 
 use atm0s_sdn::features::{FeaturesControl, FeaturesEvent};
 use media_server_protocol::{
-    endpoint::{PeerId, RoomId, TrackMeta, TrackName},
+    endpoint::{PeerId, PeerMeta, RoomId, RoomInfoPublish, RoomInfoSubscribe, TrackMeta, TrackName},
     media::MediaPacket,
 };
 
@@ -43,7 +43,7 @@ pub enum ClusterRemoteTrackControl {
     Ended,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClusterRemoteTrackEvent {
     RequestKeyFrame,
     LimitBitrate { min: u32, max: u32 },
@@ -57,7 +57,7 @@ pub enum ClusterLocalTrackControl {
     Unsubscribe,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClusterLocalTrackEvent {
     Started,
     SourceChanged,
@@ -66,21 +66,8 @@ pub enum ClusterLocalTrackEvent {
 }
 
 #[derive(Debug)]
-pub enum ClusterRoomInfoPublishLevel {
-    Full,
-    TrackOnly,
-}
-
-#[derive(Debug)]
-pub enum ClusterRoomInfoSubscribeLevel {
-    Full,
-    TrackOnly,
-    Manual,
-}
-
-#[derive(Debug)]
 pub enum ClusterEndpointControl {
-    Join(PeerId, ClusterRoomInfoPublishLevel, ClusterRoomInfoSubscribeLevel),
+    Join(PeerId, PeerMeta, RoomInfoPublish, RoomInfoSubscribe),
     Leave,
     SubscribePeer(PeerId),
     UnsubscribePeer(PeerId),
@@ -88,8 +75,10 @@ pub enum ClusterEndpointControl {
     LocalTrack(LocalTrackId, ClusterLocalTrackControl),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClusterEndpointEvent {
+    PeerJoined(PeerId, PeerMeta),
+    PeerLeaved(PeerId),
     TrackStarted(PeerId, TrackName, TrackMeta),
     TrackStopped(PeerId, TrackName),
     RemoteTrack(RemoteTrackId, ClusterRemoteTrackEvent),

--- a/packages/media_core/src/cluster/room.rs
+++ b/packages/media_core/src/cluster/room.rs
@@ -140,8 +140,8 @@ impl<Owner: Debug + Copy + Clone + Hash + Eq> ClusterRoom<Owner> {
 
     fn on_endpoint_control(&mut self, now: Instant, owner: Owner, control: ClusterEndpointControl) -> Option<Output<Owner>> {
         match control {
-            ClusterEndpointControl::Join(peer, publish, subscribe) => {
-                let out = self.metadata.on_join(owner, peer, publish, subscribe)?;
+            ClusterEndpointControl::Join(peer, meta, publish, subscribe) => {
+                let out = self.metadata.on_join(owner, peer, meta, publish, subscribe)?;
                 Some(self.process_meta_output(out))
             }
             ClusterEndpointControl::Leave => {
@@ -230,7 +230,7 @@ impl<Owner: Debug + Clone + Copy + Hash + Eq> ClusterRoom<Owner> {
     }
 }
 
-pub fn track_key<T: From<u64>>(room: ClusterRoomHash, peer: &PeerId, track: &TrackName) -> T {
+pub fn gen_channel_id<T: From<u64>>(room: ClusterRoomHash, peer: &PeerId, track: &TrackName) -> T {
     let mut h = std::hash::DefaultHasher::new();
     room.as_ref().hash(&mut h);
     peer.as_ref().hash(&mut h);

--- a/packages/media_core/src/cluster/room/channel_pub.rs
+++ b/packages/media_core/src/cluster/room/channel_pub.rs
@@ -55,7 +55,7 @@ impl<Owner: Debug + Hash + Eq + Copy> RoomChannelPublisher<Owner> {
 
     pub fn on_track_publish(&mut self, owner: Owner, track: RemoteTrackId, peer: PeerId, name: TrackName) -> Option<Output<Owner>> {
         log::info!("[ClusterRoom {}] peer ({peer} started track {name})", self.room);
-        let channel_id = super::track_key(self.room, &peer, &name);
+        let channel_id = super::gen_channel_id(self.room, &peer, &name);
         self.tracks.insert((owner, track), (peer.clone(), name.clone(), channel_id));
         self.tracks_source.insert(channel_id, (owner, track));
 

--- a/packages/media_core/src/cluster/room/channel_pub.rs
+++ b/packages/media_core/src/cluster/room/channel_pub.rs
@@ -46,7 +46,7 @@ impl<Owner: Debug + Hash + Eq + Copy> RoomChannelPublisher<Owner> {
         let (owner, track_id) = self.tracks_source.get(&channel)?;
         match fb_kind {
             FeedbackKind::Bitrate => todo!(),
-            FeedbackKind::KeyFrameRequest => Some(Output::Endpoint(vec![owner], ClusterEndpointEvent::RemoteTrack(*track_id, ClusterRemoteTrackEvent::RequestKeyFrame))),
+            FeedbackKind::KeyFrameRequest => Some(Output::Endpoint(vec![*owner], ClusterEndpointEvent::RemoteTrack(*track_id, ClusterRemoteTrackEvent::RequestKeyFrame))),
         }
     }
 

--- a/packages/media_core/src/cluster/room/channel_pub.rs
+++ b/packages/media_core/src/cluster/room/channel_pub.rs
@@ -46,10 +46,7 @@ impl<Owner: Debug + Hash + Eq + Copy> RoomChannelPublisher<Owner> {
         let (owner, track_id) = self.tracks_source.get(&channel)?;
         match fb_kind {
             FeedbackKind::Bitrate => todo!(),
-            FeedbackKind::KeyFrameRequest => Some(Output::Endpoint(
-                vec![owner.clone()],
-                ClusterEndpointEvent::RemoteTrack(*track_id, ClusterRemoteTrackEvent::RequestKeyFrame),
-            )),
+            FeedbackKind::KeyFrameRequest => Some(Output::Endpoint(vec![owner], ClusterEndpointEvent::RemoteTrack(*track_id, ClusterRemoteTrackEvent::RequestKeyFrame))),
         }
     }
 

--- a/packages/media_core/src/cluster/room/channel_sub.rs
+++ b/packages/media_core/src/cluster/room/channel_sub.rs
@@ -68,7 +68,7 @@ impl<Owner: Hash + Eq + Copy + Debug> RoomChannelSubscribe<Owner> {
     }
 
     pub fn on_track_subscribe(&mut self, owner: Owner, track: LocalTrackId, target_peer: PeerId, target_track: TrackName) -> Option<Output<Owner>> {
-        let channel_id: ChannelId = super::track_key(self.room, &target_peer, &target_track);
+        let channel_id: ChannelId = super::gen_channel_id(self.room, &target_peer, &target_track);
         log::info!(
             "[ClusterRoom {}] owner {:?} track {track} subscribe peer {target_peer} track {target_track}), channel: {channel_id}",
             self.room,

--- a/packages/media_core/src/cluster/room/channel_sub.rs
+++ b/packages/media_core/src/cluster/room/channel_sub.rs
@@ -49,7 +49,7 @@ impl<Owner: Hash + Eq + Copy + Debug> RoomChannelSubscribe<Owner> {
         log::info!("[ClusterRoom {}] cluster: channel {channel} source changed => fire event to {:?}", self.room, subscribers);
         for (owner, track) in subscribers {
             self.queue
-                .push_back(Output::Endpoint(vec![owner.clone()], ClusterEndpointEvent::LocalTrack(*track, ClusterLocalTrackEvent::SourceChanged)))
+                .push_back(Output::Endpoint(vec![*owner], ClusterEndpointEvent::LocalTrack(*track, ClusterLocalTrackEvent::SourceChanged)))
         }
         self.queue.pop_front()
     }
@@ -59,10 +59,8 @@ impl<Owner: Hash + Eq + Copy + Debug> RoomChannelSubscribe<Owner> {
         let subscribers = self.subscribers.get(&channel)?;
         log::trace!("[ClusterRoom {}] on channel media payload {} seq {} to {} subscribers", self.room, pkt.pt, pkt.seq, subscribers.len());
         for (owner, track) in subscribers {
-            self.queue.push_back(Output::Endpoint(
-                vec![owner.clone()],
-                ClusterEndpointEvent::LocalTrack(*track, ClusterLocalTrackEvent::Media(pkt.clone())),
-            ))
+            self.queue
+                .push_back(Output::Endpoint(vec![*owner], ClusterEndpointEvent::LocalTrack(*track, ClusterLocalTrackEvent::Media(pkt.clone()))))
         }
         self.queue.pop_front()
     }

--- a/packages/media_core/src/cluster/room/metadata.rs
+++ b/packages/media_core/src/cluster/room/metadata.rs
@@ -127,7 +127,7 @@ impl<Owner: Hash + Eq + Copy + Debug> RoomMetadata<Owner> {
             for (_track_key, info) in self.cluster_peers.iter() {
                 //TODO avoiding duplicate same peer
                 self.queue
-                    .push_back(Output::Endpoint(vec![owner.clone()], ClusterEndpointEvent::PeerJoined(info.peer.clone(), info.meta.clone())));
+                    .push_back(Output::Endpoint(vec![owner], ClusterEndpointEvent::PeerJoined(info.peer.clone(), info.meta.clone())));
             }
 
             // If this is first peer which subscribed to peers_map, the should send Sub
@@ -145,7 +145,7 @@ impl<Owner: Hash + Eq + Copy + Debug> RoomMetadata<Owner> {
             for (_track_key, info) in self.cluster_tracks.iter() {
                 //TODO avoiding duplicate same peer
                 self.queue.push_back(Output::Endpoint(
-                    vec![owner.clone()],
+                    vec![owner],
                     ClusterEndpointEvent::TrackStarted(info.peer.clone(), info.track.clone(), info.meta.clone()),
                 ));
             }

--- a/packages/media_core/src/endpoint.rs
+++ b/packages/media_core/src/endpoint.rs
@@ -3,7 +3,7 @@
 use std::{marker::PhantomData, time::Instant};
 
 use media_server_protocol::{
-    endpoint::{PeerId, RoomId, TrackMeta, TrackName},
+    endpoint::{PeerId, PeerMeta, RoomId, RoomInfoPublish, RoomInfoSubscribe, TrackMeta, TrackName},
     media::MediaPacket,
     transport::RpcResult,
 };
@@ -47,8 +47,10 @@ impl From<u64> for EndpointReqId {
 
 /// This is control APIs, which is used to control server from Endpoint SDK
 pub enum EndpointReq {
-    JoinRoom(RoomId, PeerId),
+    JoinRoom(RoomId, PeerId, PeerMeta, RoomInfoPublish, RoomInfoSubscribe),
     LeaveRoom,
+    SubscribePeer(PeerId),
+    UnsubscribePeer(PeerId),
     RemoteTrack(RemoteTrackId, EndpointRemoteTrackReq),
     LocalTrack(LocalTrackId, EndpointLocalTrackReq),
 }
@@ -57,6 +59,8 @@ pub enum EndpointReq {
 pub enum EndpointRes {
     JoinRoom(RpcResult<()>),
     LeaveRoom(RpcResult<()>),
+    SubscribePeer(RpcResult<()>),
+    UnsubscribePeer(RpcResult<()>),
     RemoteTrack(RemoteTrackId, EndpointRemoteTrackRes),
     LocalTrack(LocalTrackId, EndpointLocalTrackRes),
 }
@@ -73,6 +77,8 @@ pub enum EndpointRemoteTrackEvent {
 }
 
 pub enum EndpointEvent {
+    PeerJoined(PeerId, PeerMeta),
+    PeerLeaved(PeerId),
     PeerTrackStarted(PeerId, TrackName, TrackMeta),
     PeerTrackStopped(PeerId, TrackName),
     RemoteMediaTrack(RemoteTrackId, EndpointRemoteTrackEvent),

--- a/packages/media_core/src/endpoint/internal/local_track.rs
+++ b/packages/media_core/src/endpoint/internal/local_track.rs
@@ -101,7 +101,7 @@ impl EndpointLocalTrack {
                     Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Ok(()))))
                 } else {
                     log::warn!("[EndpointLocalTrack] view but not in room");
-                    Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Err(RpcError::new2(EndpointErrors::LocalTrackSwitchNotInRoom)))))
+                    Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Err(RpcError::new2(EndpointErrors::EndpointNotInRoom)))))
                 }
             }
             EndpointLocalTrackReq::Switch(None) => {
@@ -112,11 +112,11 @@ impl EndpointLocalTrack {
                         Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Ok(()))))
                     } else {
                         log::warn!("[EndpointLocalTrack] unview but not bind to any source");
-                        Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Err(RpcError::new2(EndpointErrors::LocalTrackSwitchNotPin)))))
+                        Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Err(RpcError::new2(EndpointErrors::LocalTrackNotPinSource)))))
                     }
                 } else {
                     log::warn!("[EndpointLocalTrack] unview but not in room");
-                    Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Err(RpcError::new2(EndpointErrors::LocalTrackSwitchNotInRoom)))))
+                    Some(Output::RpcRes(req_id, EndpointLocalTrackRes::Switch(Err(RpcError::new2(EndpointErrors::EndpointNotInRoom)))))
                 }
             }
         }

--- a/packages/media_core/src/errors.rs
+++ b/packages/media_core/src/errors.rs
@@ -1,8 +1,9 @@
 #[derive(Debug, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
 #[repr(u16)]
 pub enum EndpointErrors {
-    LocalTrackSwitchNotInRoom = 0x0000,
-    LocalTrackSwitchNotPin = 0x0001,
+    EndpointNotInRoom = 0x0001,
+    LocalTrackNotPinSource = 0x1001,
+    RemoteTrack_ = 0x2001,
 }
 
 impl ToString for EndpointErrors {

--- a/packages/protocol/src/endpoint.rs
+++ b/packages/protocol/src/endpoint.rs
@@ -102,19 +102,90 @@ impl ConnLayer for usize {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct RoomInfoPublish {
+    pub peer: bool,
+    pub tracks: bool,
+}
+
+#[derive(Debug)]
+pub struct RoomInfoSubscribe {
+    pub peers: bool,
+    pub tracks: bool,
+}
+
 #[derive(From, AsRef, Debug, derive_more::Display, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RoomId(pub String);
 
 #[derive(From, AsRef, Debug, derive_more::Display, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PeerId(pub String);
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerMeta {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerInfo {
+    pub peer: PeerId,
+    pub meta: PeerMeta,
+}
+
+impl PeerInfo {
+    pub fn new(peer: PeerId, meta: PeerMeta) -> Self {
+        Self { peer, meta }
+    }
+}
+
+impl PeerInfo {
+    pub fn serialize(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("should ok")
+    }
+
+    pub fn deserialize(data: &[u8]) -> Option<PeerInfo> {
+        bincode::deserialize::<Self>(data).ok()
+    }
+}
+
 #[derive(From, AsRef, Debug, derive_more::Display, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TrackName(pub String);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TrackMeta {
     pub kind: MediaKind,
     pub scaling: MediaScaling,
+}
+
+impl TrackMeta {
+    pub fn default_audio() -> Self {
+        Self {
+            kind: MediaKind::Audio,
+            scaling: MediaScaling::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackInfo {
+    pub peer: PeerId,
+    pub track: TrackName,
+    pub meta: TrackMeta,
+}
+
+impl TrackInfo {
+    pub fn simple_audio(peer: PeerId) -> Self {
+        Self {
+            peer,
+            track: "audio_main".to_string().into(),
+            meta: TrackMeta::default_audio(),
+        }
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("should ok")
+    }
+
+    pub fn deserialize(data: &[u8]) -> Option<TrackInfo> {
+        bincode::deserialize::<Self>(data).ok()
+    }
 }
 
 #[cfg(test)]

--- a/packages/protocol/src/media.rs
+++ b/packages/protocol/src/media.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::endpoint::{PeerId, TrackMeta, TrackName};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MediaKind {
     Audio,
     Video,
@@ -19,7 +19,7 @@ impl MediaKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MediaScaling {
     None,
     Simulcat,
@@ -34,7 +34,7 @@ pub enum MediaCodec {
     Vp9,
 }
 
-#[derive(Derivative, Clone, Serialize, Deserialize)]
+#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[derivative(Debug)]
 pub struct MediaPacket {
     pub pt: u8,
@@ -52,23 +52,6 @@ impl MediaPacket {
     }
 
     pub fn deserialize(data: &[u8]) -> Option<MediaPacket> {
-        bincode::deserialize::<Self>(data).ok()
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct TrackInfo {
-    pub peer: PeerId,
-    pub track: TrackName,
-    pub meta: TrackMeta,
-}
-
-impl TrackInfo {
-    pub fn serialize(&self) -> Vec<u8> {
-        bincode::serialize(self).expect("should ok")
-    }
-
-    pub fn deserialize(data: &[u8]) -> Option<TrackInfo> {
         bincode::deserialize::<Self>(data).ok()
     }
 }

--- a/packages/transport_webrtc/src/transport/whep.rs
+++ b/packages/transport_webrtc/src/transport/whep.rs
@@ -118,7 +118,14 @@ impl TransportWebrtcInternal for TransportWebrtcWhep {
             }
             EndpointEvent::PeerTrackStopped(peer, track) => self.try_unsubscribe(peer, track),
             EndpointEvent::LocalMediaTrack(_track, event) => match event {
-                EndpointLocalTrackEvent::Media(pkt) => Some(InternalOutput::Str0mSendMedia(self.video_mid?, pkt)),
+                EndpointLocalTrackEvent::Media(pkt) => {
+                    let mid = if pkt.pt == 111 {
+                        self.audio_mid
+                    } else {
+                        self.video_mid
+                    }?;
+                    Some(InternalOutput::Str0mSendMedia(mid, pkt))
+                }
             },
             EndpointEvent::RemoteMediaTrack(_track, _event) => None,
             EndpointEvent::GoAway(_seconds, _reason) => None,

--- a/packages/transport_webrtc/src/transport/whip.rs
+++ b/packages/transport_webrtc/src/transport/whip.rs
@@ -8,7 +8,7 @@ use media_server_core::{
     transport::{RemoteTrackEvent, RemoteTrackId, TransportError, TransportEvent, TransportOutput, TransportState},
 };
 use media_server_protocol::{
-    endpoint::{PeerId, RoomId, TrackMeta},
+    endpoint::{PeerId, PeerMeta, RoomId, RoomInfoPublish, RoomInfoSubscribe, TrackMeta},
     media::{MediaKind, MediaScaling},
 };
 use str0m::{
@@ -95,6 +95,8 @@ impl TransportWebrtcInternal for TransportWebrtcWhip {
 
     fn on_endpoint_event<'a>(&mut self, _now: Instant, event: EndpointEvent) -> Option<InternalOutput<'a>> {
         match event {
+            EndpointEvent::PeerJoined(_, _) => None,
+            EndpointEvent::PeerLeaved(_) => None,
             EndpointEvent::PeerTrackStarted(_, _, _) => None,
             EndpointEvent::PeerTrackStopped(_, _) => None,
             EndpointEvent::RemoteMediaTrack(_, event) => match event {
@@ -124,7 +126,13 @@ impl TransportWebrtcInternal for TransportWebrtcWhip {
                 log::info!("[TransportWebrtcWhip] connected");
                 self.queue.push_back(InternalOutput::TransportOutput(TransportOutput::RpcReq(
                     0.into(),
-                    EndpointReq::JoinRoom(self.room.clone(), self.peer.clone()),
+                    EndpointReq::JoinRoom(
+                        self.room.clone(),
+                        self.peer.clone(),
+                        PeerMeta {},
+                        RoomInfoPublish { peer: true, tracks: true },
+                        RoomInfoSubscribe { peers: false, tracks: false },
+                    ),
                 )));
                 return Some(InternalOutput::TransportOutput(TransportOutput::Event(TransportEvent::State(TransportState::Connected))));
             }


### PR DESCRIPTION
## Pull Request

### Description

This PR implement cluster metadata feature

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced room and peer management functionalities across the platform.
  - New event handling for peer join and leave actions.
  - Improved error messaging for track-related issues.

- **Refactor**
  - Updated method parameters and internal logic for better handling of media tracks and peer metadata.
  - Renamed key identifiers to align with new naming conventions.

- **Bug Fixes**
  - Adjusted data structures and logic to fix issues related to media scaling and packet handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->