### PR TITLE
fix: missing clear room_map in cluster cause room failed to restart

### DIFF
--- a/packages/media_core/src/cluster/room.rs
+++ b/packages/media_core/src/cluster/room.rs
@@ -30,7 +30,7 @@ pub enum Input<Owner> {
 pub enum Output<Owner> {
     Sdn(ClusterRoomHash, FeaturesControl),
     Endpoint(Vec<Owner>, ClusterEndpointEvent),
-    Destroy,
+    Destroy(ClusterRoomHash),
 }
 
 #[derive(num_enum::TryFromPrimitive)]
@@ -90,7 +90,7 @@ impl<Owner: Debug + Copy + Clone + Hash + Eq> Task<Input<Owner>, Output<Owner>> 
         if self.metadata.peers() == 0 && !self.destroyed {
             log::info!("[ClusterRoom {}] leave last peer => remove room", self.room);
             self.destroyed = true;
-            Some(Output::Destroy)
+            Some(Output::Destroy(self.room))
         } else {
             None
         }


### PR DESCRIPTION
## Pull Request

### Description

Please provide a brief description of the changes made in this pull request.

### Related Issue

This PR fix missing clear room_map in cluster cause room failed to restart

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
