### PR TITLE
Feat: Virtual DataChannel

### DIFF
--- a/packages/media_core/src/cluster.rs
+++ b/packages/media_core/src/cluster.rs
@@ -90,7 +90,7 @@ pub enum ClusterEndpointControl {
     LocalTrack(LocalTrackId, ClusterLocalTrackControl),
     SubscribeChannel(String),
     UnsubscribeChannel(String),
-    PublishChannel(String, PeerId, String),
+    PublishChannel(String, PeerId, Vec<u8>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -102,7 +102,7 @@ pub enum ClusterEndpointEvent {
     AudioMixer(ClusterAudioMixerEvent),
     RemoteTrack(RemoteTrackId, ClusterRemoteTrackEvent),
     LocalTrack(LocalTrackId, ClusterLocalTrackEvent),
-    ChannelMessage(String, PeerId, String),
+    ChannelMessage(String, PeerId, Vec<u8>),
 }
 
 pub enum Input<Endpoint> {

--- a/packages/media_core/src/cluster.rs
+++ b/packages/media_core/src/cluster.rs
@@ -88,6 +88,9 @@ pub enum ClusterEndpointControl {
     AudioMixer(ClusterAudioMixerControl),
     RemoteTrack(RemoteTrackId, ClusterRemoteTrackControl),
     LocalTrack(LocalTrackId, ClusterLocalTrackControl),
+    SubscribeChannel(String),
+    UnsubscribeChannel(String),
+    PublishChannel(String, PeerId, String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -99,6 +102,7 @@ pub enum ClusterEndpointEvent {
     AudioMixer(ClusterAudioMixerEvent),
     RemoteTrack(RemoteTrackId, ClusterRemoteTrackEvent),
     LocalTrack(LocalTrackId, ClusterLocalTrackEvent),
+    ChannelMessage(String, PeerId, String),
 }
 
 pub enum Input<Endpoint> {

--- a/packages/media_core/src/cluster/id_generator.rs
+++ b/packages/media_core/src/cluster/id_generator.rs
@@ -41,11 +41,10 @@ pub fn gen_track_channel_id<T: From<u64>>(room: ClusterRoomHash, peer: &PeerId, 
     h.finish().into()
 }
 
-pub fn gen_datachannel_id<T: From<u64>, Endpoint: Hash>(room: ClusterRoomHash, endpoint: Endpoint, key: String) -> T {
+pub fn gen_datachannel_id<T: From<u64>>(room: ClusterRoomHash, key: String) -> T {
     let mut h = std::hash::DefaultHasher::new();
     room.as_ref().hash(&mut h);
     key.hash(&mut h);
-    endpoint.hash(&mut h);
     "datachannel".hash(&mut h);
     h.finish().into()
 }

--- a/packages/media_core/src/cluster/id_generator.rs
+++ b/packages/media_core/src/cluster/id_generator.rs
@@ -33,11 +33,20 @@ pub fn tracks_key(peer: &PeerId, track: &TrackName) -> Key {
     h.finish().into()
 }
 
-pub fn gen_channel_id<T: From<u64>>(room: ClusterRoomHash, peer: &PeerId, track: &TrackName) -> T {
+pub fn gen_track_channel_id<T: From<u64>>(room: ClusterRoomHash, peer: &PeerId, track: &TrackName) -> T {
     let mut h = std::hash::DefaultHasher::new();
     room.as_ref().hash(&mut h);
     peer.as_ref().hash(&mut h);
     track.as_ref().hash(&mut h);
+    h.finish().into()
+}
+
+pub fn gen_datachannel_id<T: From<u64>, Endpoint: Hash>(room: ClusterRoomHash, endpoint: Endpoint, key: String) -> T {
+    let mut h = std::hash::DefaultHasher::new();
+    room.as_ref().hash(&mut h);
+    key.hash(&mut h);
+    endpoint.hash(&mut h);
+    "datachannel".hash(&mut h);
     h.finish().into()
 }
 

--- a/packages/media_core/src/cluster/room.rs
+++ b/packages/media_core/src/cluster/room.rs
@@ -160,7 +160,7 @@ impl<Endpoint: Debug + Copy + Clone + Hash + Eq> ClusterRoom<Endpoint> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.metadata.is_empty() && self.media_track.is_empty() && self.audio_mixer.is_empty()
+        self.metadata.is_empty() && self.media_track.is_empty() && self.audio_mixer.is_empty() && self.datachannel.is_empty()
     }
 
     fn on_sdn_event(&mut self, now: Instant, userdata: RoomUserData, event: FeaturesEvent) {
@@ -191,6 +191,7 @@ impl<Endpoint: Debug + Copy + Clone + Hash + Eq> ClusterRoom<Endpoint> {
             ClusterEndpointControl::Leave => {
                 self.audio_mixer.input(&mut self.switcher).on_leave(now, endpoint);
                 self.metadata.input(&mut self.switcher).on_leave(endpoint);
+                self.datachannel.input(&mut self.switcher).on_leave(endpoint);
             }
             ClusterEndpointControl::SubscribePeer(target) => {
                 self.metadata.input(&mut self.switcher).on_subscribe_peer(endpoint, target);
@@ -206,7 +207,7 @@ impl<Endpoint: Debug + Copy + Clone + Hash + Eq> ClusterRoom<Endpoint> {
             ClusterEndpointControl::SubscribeChannel(key) => self.datachannel.input(&mut self.switcher).on_channel_subscribe(endpoint, &key),
             ClusterEndpointControl::PublishChannel(key, peer, message) => {
                 let data_packet = DataChannelPacket { from: peer, data: message };
-                self.datachannel.input(&mut self.switcher).on_channel_data(endpoint, &key, data_packet);
+                self.datachannel.input(&mut self.switcher).on_channel_data(&key, data_packet);
             }
             ClusterEndpointControl::UnsubscribeChannel(key) => self.datachannel.input(&mut self.switcher).on_channel_unsubscribe(endpoint, &key),
         }
@@ -260,6 +261,7 @@ impl<Endpoint: Debug + Copy + Clone + Hash + Eq> Drop for ClusterRoom<Endpoint> 
         assert!(self.audio_mixer.is_empty(), "Audio mixer not empty");
         assert!(self.media_track.is_empty(), "Media track not empty");
         assert!(self.metadata.is_empty(), "Metadata not empty");
+        assert!(self.datachannel.is_empty(), "Data channel not empty");
     }
 }
 

--- a/packages/media_core/src/cluster/room/audio_mixer/manual.rs
+++ b/packages/media_core/src/cluster/room/audio_mixer/manual.rs
@@ -51,7 +51,7 @@ impl<Endpoint: Clone> ManualMixer<Endpoint> {
     }
 
     fn attach(&mut self, _now: Instant, source: TrackSource) {
-        let channel_id = id_generator::gen_channel_id(self.room, &source.peer, &source.track);
+        let channel_id = id_generator::gen_track_channel_id(self.room, &source.peer, &source.track);
         if !self.sources.contains_key(&channel_id) {
             log::info!("[ClusterManualMixer] add source {:?} => sub {channel_id}", source);
             self.sources.insert(channel_id, source);
@@ -84,7 +84,7 @@ impl<Endpoint: Clone> ManualMixer<Endpoint> {
     }
 
     fn detach(&mut self, _now: Instant, source: TrackSource) {
-        let channel_id = id_generator::gen_channel_id(self.room, &source.peer, &source.track);
+        let channel_id = id_generator::gen_track_channel_id(self.room, &source.peer, &source.track);
         if let Some(_) = self.sources.remove(&channel_id) {
             log::info!("[ClusterManualMixer] remove source {:?} => unsub {channel_id}", source);
             self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, pubsub::ChannelControl::UnsubAuto)));
@@ -183,7 +183,7 @@ mod test {
             peer: "peer1".into(),
             track: "audio".into(),
         };
-        let channel_id = id_generator::gen_channel_id(room, &source.peer, &source.track);
+        let channel_id = id_generator::gen_track_channel_id(room, &source.peer, &source.track);
 
         manual.attach(t0, source.clone());
         assert_eq!(manual.pop_output(()), Some(Output::Pubsub(pubsub::Control(channel_id, pubsub::ChannelControl::SubAuto))));
@@ -234,7 +234,7 @@ mod test {
             peer: "peer1".into(),
             track: "audio".into(),
         };
-        let channel_id = id_generator::gen_channel_id(room, &source.peer, &source.track);
+        let channel_id = id_generator::gen_track_channel_id(room, &source.peer, &source.track);
 
         manual.attach(t0, source.clone());
         assert_eq!(manual.pop_output(()), Some(Output::Pubsub(pubsub::Control(channel_id, pubsub::ChannelControl::SubAuto))));

--- a/packages/media_core/src/cluster/room/datachannel.rs
+++ b/packages/media_core/src/cluster/room/datachannel.rs
@@ -1,0 +1,110 @@
+use std::{fmt::Debug, hash::Hash};
+
+use atm0s_sdn::features::pubsub::{self};
+use media_server_protocol::datachannel::DataChannelPacket;
+use publisher::DataChannelPublisher;
+use sans_io_runtime::{TaskSwitcher, TaskSwitcherBranch, TaskSwitcherChild};
+use subscriber::DataChannelSubscriber;
+
+use crate::cluster::{ClusterEndpointEvent, ClusterRoomHash};
+
+mod publisher;
+mod subscriber;
+
+#[derive(num_enum::IntoPrimitive, num_enum::TryFromPrimitive)]
+#[repr(usize)]
+pub enum TaskType {
+    Publisher = 0,
+    Subscriber = 1,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Output<Endpoint> {
+    Pubsub(pubsub::Control),
+    Endpoint(Vec<Endpoint>, ClusterEndpointEvent),
+    OnResourceEmpty,
+}
+
+pub struct RoomChannel<Endpoint> {
+    room: ClusterRoomHash,
+    publisher: TaskSwitcherBranch<DataChannelPublisher<Endpoint>, Output<Endpoint>>,
+    subscriber: TaskSwitcherBranch<DataChannelSubscriber<Endpoint>, Output<Endpoint>>,
+    switcher: TaskSwitcher,
+}
+
+impl<Endpoint: Hash + Eq + Copy + Debug> RoomChannel<Endpoint> {
+    pub fn new(room: ClusterRoomHash) -> Self {
+        log::info!("[ClusterRoomMetadata] Create {}", room);
+        Self {
+            room,
+            publisher: TaskSwitcherBranch::new(DataChannelPublisher::new(room), TaskType::Publisher),
+            subscriber: TaskSwitcherBranch::new(DataChannelSubscriber::new(room), TaskType::Subscriber),
+            switcher: TaskSwitcher::new(2),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.publisher.is_empty() && self.subscriber.is_empty()
+    }
+
+    pub fn on_pubsub_event(&mut self, event: pubsub::Event) {
+        let channel = event.0;
+        match event.1 {
+            pubsub::ChannelEvent::SourceData(_, data) => {
+                self.subscriber.input(&mut self.switcher).on_channel_data(channel, data);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn on_channel_data(&mut self, endpoint: Endpoint, key: &str, data: DataChannelPacket) {
+        self.publisher.input(&mut self.switcher).on_channel_data(endpoint, key, data);
+    }
+
+    pub fn on_channel_subscribe(&mut self, endpoint: Endpoint, key: &str) {
+        self.subscriber.input(&mut self.switcher).on_channel_subscribe(endpoint, key);
+    }
+
+    pub fn on_channel_unsubscribe(&mut self, endpoint: Endpoint, key: &str) {
+        self.subscriber.input(&mut self.switcher).on_channel_unsubscribe(endpoint, key);
+    }
+}
+
+impl<Endpoint: Debug + Hash + Eq + Copy> TaskSwitcherChild<Output<Endpoint>> for RoomChannel<Endpoint> {
+    type Time = ();
+
+    fn pop_output(&mut self, _now: Self::Time) -> Option<Output<Endpoint>> {
+        loop {
+            match self.switcher.current()?.try_into().ok()? {
+                TaskType::Publisher => {
+                    if let Some(out) = self.publisher.pop_output((), &mut self.switcher) {
+                        if let Output::OnResourceEmpty = out {
+                            if self.is_empty() {
+                                return Some(Output::OnResourceEmpty);
+                            }
+                        } else {
+                            return Some(out);
+                        }
+                    }
+                }
+                TaskType::Subscriber => {
+                    if let Some(out) = self.subscriber.pop_output((), &mut self.switcher) {
+                        if let Output::OnResourceEmpty = out {
+                            if self.is_empty() {
+                                return Some(Output::OnResourceEmpty);
+                            }
+                        } else {
+                            return Some(out);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<Endpoint> Drop for RoomChannel<Endpoint> {
+    fn drop(&mut self) {
+        log::info!("[ClusterRoomDataChannel] Drop {}", self.room);
+    }
+}

--- a/packages/media_core/src/cluster/room/datachannel/publisher.rs
+++ b/packages/media_core/src/cluster/room/datachannel/publisher.rs
@@ -1,0 +1,57 @@
+use std::{collections::VecDeque, fmt::Debug, hash::Hash};
+
+use atm0s_sdn::features::pubsub::{self, ChannelControl, ChannelId};
+use media_server_protocol::datachannel::DataChannelPacket;
+use sans_io_runtime::TaskSwitcherChild;
+
+use crate::cluster::{id_generator, ClusterRoomHash};
+
+use super::Output;
+
+pub struct DataChannelPublisher<Endpoint> {
+    room: ClusterRoomHash,
+    queue: VecDeque<Output<Endpoint>>,
+}
+
+impl<Endpoint: Hash + Eq + Copy + Debug> DataChannelPublisher<Endpoint> {
+    pub fn new(room: ClusterRoomHash) -> Self {
+        Self { room, queue: VecDeque::new() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    pub fn on_channel_publish(&mut self, endpoint: Endpoint, key: &str) {
+        log::trace!("[ClusterRoom {}/Publishers] peer {:?} publish datachannel", self.room, endpoint);
+        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, endpoint, key.to_string());
+        self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStart)))
+    }
+
+    pub fn on_channel_data(&mut self, endpoint: Endpoint, key: &str, data: DataChannelPacket) {
+        log::trace!("[ClusterRoom {}/Publishers] peer {:?} publish datachannel", self.room, endpoint);
+        let data = data.serialize();
+        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, endpoint, key.to_string());
+        self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubData(data))))
+    }
+
+    pub fn on_channel_unpublish(&mut self, endpoint: Endpoint, key: &str) {
+        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, endpoint, key.to_string());
+        log::info!("[ClusterRoom {}/Publishers] peer {:?} stopped datachannel", self.room, endpoint);
+        self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStop)));
+    }
+}
+
+impl<Endpoint: Debug + Hash + Eq + Copy> TaskSwitcherChild<Output<Endpoint>> for DataChannelPublisher<Endpoint> {
+    type Time = ();
+    fn pop_output(&mut self, _now: Self::Time) -> Option<Output<Endpoint>> {
+        self.queue.pop_front()
+    }
+}
+
+impl<Endpoint> Drop for DataChannelPublisher<Endpoint> {
+    fn drop(&mut self) {
+        log::info!("[ClusterRoom {}/Publishers] Drop", self.room);
+        assert_eq!(self.queue.len(), 0, "Queue not empty on drop");
+    }
+}

--- a/packages/media_core/src/cluster/room/datachannel/subscriber.rs
+++ b/packages/media_core/src/cluster/room/datachannel/subscriber.rs
@@ -16,14 +16,14 @@ use super::Output;
 #[derive(Derivative)]
 #[derivative(Default(bound = ""))]
 struct ChannelContainer<Endpoint> {
-    subscribers: Vec<Endpoint>,
+    subscribers: HashMap<Endpoint, ()>,
     key: String,
 }
 
 pub struct DataChannelSubscriber<Endpoint> {
     room: ClusterRoomHash,
     channels: HashMap<ChannelId, ChannelContainer<Endpoint>>,
-    // subscribers: HashMap<Endpoint, (ChannelId, PeerId)>,
+    subscribers: HashMap<Endpoint, Vec<ChannelId>>,
     queue: VecDeque<Output<Endpoint>>,
 }
 
@@ -33,6 +33,7 @@ impl<Endpoint: Hash + Eq + Copy + Debug> DataChannelSubscriber<Endpoint> {
             room,
             queue: VecDeque::new(),
             channels: HashMap::new(),
+            subscribers: HashMap::new(),
         }
     }
 
@@ -41,48 +42,94 @@ impl<Endpoint: Hash + Eq + Copy + Debug> DataChannelSubscriber<Endpoint> {
     }
 
     pub fn on_channel_subscribe(&mut self, endpoint: Endpoint, key: &str) {
-        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, endpoint, key.to_string());
-        log::info!("[ClusterRoom {}/Subscribers] peer {:?} subscribe channel: {channel_id}", self.room, endpoint);
-        let channel_container = self.channels.entry(channel_id).or_insert(ChannelContainer {
-            subscribers: vec![],
-            key: key.to_string(),
+        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, key.to_string());
+        log::info!("[ClusterRoomDataChannel {}/Subscribers] peer {:?} subscribe channel: {channel_id}", self.room, endpoint);
+        let channel_container = self.channels.entry(channel_id).or_insert_with(|| {
+            let channel = ChannelContainer {
+                subscribers: HashMap::new(),
+                key: key.to_string(),
+            };
+            self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStart)));
+            channel
         });
-        channel_container.subscribers.push(endpoint);
+
+        if let Some(subscriber) = self.subscribers.get_mut(&endpoint) {
+            if !channel_container.subscribers.contains_key(&endpoint) {
+                subscriber.push(channel_id);
+            }
+        } else {
+            self.subscribers.insert(endpoint, vec![channel_id]);
+        }
+        channel_container.subscribers.insert(endpoint, ());
+
         if channel_container.subscribers.len() == 1 {
-            log::info!("[ClusterRoom {}/Subscribers] first subscriber => Sub channel {channel_id}", self.room);
+            log::info!("[ClusterRoomDataChannel {}/Subscribers] first subscriber => Sub channel {channel_id}", self.room);
             self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::SubAuto)));
         }
     }
 
     pub fn on_channel_unsubscribe(&mut self, endpoint: Endpoint, key: &str) {
-        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, endpoint, key.to_string());
-        log::info!("[ClusterRoom {}/Subscribers] peer {:?} unsubscribe channel: {channel_id}", self.room, endpoint);
-        if let Some(channel_container) = self.channels.get_mut(&channel_id) {
-            if let Some(index) = channel_container.subscribers.iter().position(|x| *x == endpoint) {
-                channel_container.subscribers.swap_remove(index);
+        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, key.to_string());
+        log::info!("[ClusterRoomDataChannel {}/Subscribers] peer {:?} unsubscribe channel: {channel_id}", self.room, endpoint);
+        let channel_container = return_if_none!(self.channels.get_mut(&channel_id));
+        if channel_container.subscribers.contains_key(&endpoint) {
+            channel_container.subscribers.remove(&endpoint);
+            if let Some(endpoint_subscriptions) = self.subscribers.get_mut(&endpoint) {
+                if let Some(index) = endpoint_subscriptions.iter().position(|x| *x == channel_id) {
+                    endpoint_subscriptions.swap_remove(index);
+                }
+
+                if endpoint_subscriptions.is_empty() {
+                    self.subscribers.remove(&endpoint);
+                }
+            }
+            if channel_container.subscribers.is_empty() {
+                log::info!("[ClusterRoomDataChannel {}/Subscribers] last subscriber => Unsub channel {channel_id}", self.room);
+                self.channels.remove(&channel_id);
+                self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::UnsubAuto)));
+                self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStop)));
+                if self.channels.is_empty() {
+                    log::info!("[ClusterRoomDataChannel {}/Subscribers] last channel => Stop channel {channel_id}", self.room);
+                    self.queue.push_back(Output::OnResourceEmpty);
+                }
+            }
+        } else {
+            log::warn!("[ClusterRoomDataChannel {}/Subscribers] peer {:?} not subscribe in channel {channel_id}", self.room, endpoint);
+        }
+    }
+
+    pub fn on_leave(&mut self, endpoint: Endpoint) {
+        log::info!("[ClusterRoomDataChannel {}/Subscribers] peer {:?} leave", self.room, endpoint);
+        let subscriber = return_if_none!(self.subscribers.remove(&endpoint));
+        for channel_id in subscriber {
+            if let Some(channel_container) = self.channels.get_mut(&channel_id) {
+                channel_container.subscribers.remove(&endpoint);
                 if channel_container.subscribers.is_empty() {
-                    log::info!("[ClusterRoom {}/Subscribers] last subscriber => Unsub channel {channel_id}", self.room);
+                    log::info!("[ClusterRoomDataChannel {}/Subscribers] last subscriber => Unsub channel {channel_id}", self.room);
                     self.channels.remove(&channel_id);
                     self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::UnsubAuto)));
+                    self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStop)));
                 }
-            } else {
-                log::warn!("[ClusterRoom {}/Subscribers] peer {:?} not subscribe in channel {channel_id}", self.room, endpoint);
+                if self.channels.is_empty() {
+                    log::info!("[ClusterRoomDataChannel {}/Subscribers] last channel => Stop channel {channel_id}", self.room);
+                    self.queue.push_back(Output::OnResourceEmpty);
+                }
             }
         }
     }
 
     pub fn on_channel_data(&mut self, channel_id: ChannelId, data: Vec<u8>) {
-        log::info!("[ClusterRoom {}/Subscribers] Receive data from channel {channel_id}", self.room);
+        log::info!("[ClusterRoomDataChannel {}/Subscribers] Receive data from channel {channel_id}", self.room);
         let pkt = return_if_none!(DataChannelPacket::deserialize(&data));
         if let Some(channel_container) = self.channels.get(&channel_id) {
             for endpoint in &channel_container.subscribers {
                 self.queue.push_back(Output::Endpoint(
-                    vec![*endpoint],
+                    vec![*endpoint.0],
                     ClusterEndpointEvent::ChannelMessage(channel_container.key.clone(), pkt.from.clone(), pkt.data.clone()),
                 ));
             }
         } else {
-            log::warn!("[ClusterRoom {}/Subscribers] Receive data from unknown channel {channel_id}", self.room);
+            log::warn!("[ClusterRoomDataChannel {}/Subscribers] Receive data from unknown channel {channel_id}", self.room);
         }
     }
 }
@@ -96,8 +143,167 @@ impl<Endpoint: Debug + Hash + Eq + Copy> TaskSwitcherChild<Output<Endpoint>> for
 
 impl<Endpoint> Drop for DataChannelSubscriber<Endpoint> {
     fn drop(&mut self) {
-        log::info!("[ClusterRoom {}/Subscriber] Drop", self.room);
+        log::info!("[ClusterRoomDataChannel {}/Subscriber] Drop", self.room);
         assert_eq!(self.queue.len(), 0, "Queue not empty on drop");
         assert_eq!(self.channels.len(), 0, "Channels not empty on drop");
+        assert_eq!(self.subscribers.len(), 0, "Subscribers not empty on drop");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use atm0s_sdn::features::pubsub::{self, ChannelControl};
+    use media_server_protocol::{datachannel::DataChannelPacket, endpoint::PeerId};
+    use sans_io_runtime::TaskSwitcherChild;
+
+    use crate::cluster::{
+        id_generator,
+        room::datachannel::{subscriber::DataChannelSubscriber, Output},
+        ClusterEndpointEvent,
+    };
+
+    #[test]
+    fn sub_unsub() {
+        let now = ();
+        let room = 1.into();
+        let mut subscriber = DataChannelSubscriber::new(room);
+        let endpoint1 = 1;
+        let endpoint2 = 2;
+        let endpoint3 = 3;
+        let key = "test";
+        let key2 = "test2";
+
+        // 1 -> test
+        // 2 -> test
+        // 3 -> test2
+
+        subscriber.on_channel_subscribe(endpoint1, key);
+        let channel_id = id_generator::gen_datachannel_id(room, key.to_string());
+        let channel_id2 = id_generator::gen_datachannel_id(room, key2.to_string());
+
+        assert!(!subscriber.is_empty());
+        // First subscriber will start publish and subscribe on pubsub channel
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStart))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::SubAuto))));
+        assert_eq!(subscriber.pop_output(now), None);
+
+        // Second subscriber will do nothing but register in the subscriber list
+        subscriber.on_channel_subscribe(endpoint2, key);
+        assert_eq!(subscriber.pop_output(now), None);
+
+        // First subscriber of a new channel should start publish and subscribe too
+        subscriber.on_channel_subscribe(endpoint3, key2);
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id2, ChannelControl::PubStart))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id2, ChannelControl::SubAuto))));
+
+        subscriber.on_channel_unsubscribe(endpoint1, key);
+        subscriber.on_channel_unsubscribe(endpoint2, key);
+
+        // Last subscriber that unsubscribes will stop the channel
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::UnsubAuto))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStop))));
+
+        // Last channel that unsubscribes will stop publish and return empty resource
+        subscriber.on_channel_unsubscribe(endpoint3, key2);
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id2, ChannelControl::UnsubAuto))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id2, ChannelControl::PubStop))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::OnResourceEmpty));
+
+        assert!(subscriber.is_empty());
+    }
+
+    #[test]
+    fn receive_data() {
+        let now = ();
+        let room = 1.into();
+        let mut subscriber = DataChannelSubscriber::new(room);
+        let endpoint1 = 1;
+        let endpoint2 = 2;
+        let endpoint3 = 3;
+        let key = "test";
+        let key_fake = "different_channel";
+
+        let channel_id = id_generator::gen_datachannel_id(room, key.to_string());
+        let channel_id_fake = id_generator::gen_datachannel_id(room, key_fake.to_string());
+
+        subscriber.on_channel_subscribe(endpoint1, key);
+        subscriber.on_channel_subscribe(endpoint2, key);
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStart))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::SubAuto))));
+        assert_eq!(subscriber.pop_output(now), None);
+
+        subscriber.on_channel_subscribe(endpoint3, key_fake);
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id_fake, ChannelControl::PubStart))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id_fake, ChannelControl::SubAuto))));
+        assert_eq!(subscriber.pop_output(now), None);
+
+        let peer_id = PeerId::from("testid");
+        let pkt = DataChannelPacket {
+            from: peer_id.clone(),
+            data: vec![1, 2, 3],
+        };
+        subscriber.on_channel_data(channel_id, pkt.clone().serialize());
+        let mut receivers = HashMap::new();
+        receivers.insert(endpoint1, false);
+        receivers.insert(endpoint2, false);
+        receivers.insert(endpoint3, false);
+
+        while let Some(out) = subscriber.pop_output(now) {
+            match out {
+                Output::Endpoint(endpoint, ClusterEndpointEvent::ChannelMessage(key, peer, data)) => {
+                    assert_eq!(key, key);
+                    assert_eq!(peer, peer_id);
+                    assert_eq!(data, pkt.data);
+                    assert!(receivers.contains_key(&endpoint[0]));
+                    *receivers.get_mut(&endpoint[0]).unwrap() = true;
+                }
+                _ => panic!("Unexpected output: {:?}", out),
+            }
+        }
+
+        // Every endpoint 1 and 2 should received the message
+        // Endpoint 3 should not receive anything
+        assert!(receivers[&endpoint1]);
+        assert!(receivers[&endpoint2]);
+        assert!(!receivers[&endpoint3]);
+        assert_eq!(subscriber.pop_output(now), None);
+
+        subscriber.on_channel_unsubscribe(endpoint1, key);
+        subscriber.on_channel_unsubscribe(endpoint2, key);
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::UnsubAuto))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStop))));
+        subscriber.on_channel_unsubscribe(endpoint3, key_fake);
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id_fake, ChannelControl::UnsubAuto))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id_fake, ChannelControl::PubStop))));
+
+        assert_eq!(subscriber.pop_output(now), Some(Output::OnResourceEmpty));
+    }
+
+    #[test]
+    fn leave_room() {
+        let now = ();
+        let room = 1.into();
+        let mut subscriber = DataChannelSubscriber::new(room);
+        let endpoint1 = 1;
+        let endpoint2 = 2;
+        let key = "test";
+
+        let channel_id = id_generator::gen_datachannel_id(room, key.to_string());
+
+        subscriber.on_channel_subscribe(endpoint1, key);
+        subscriber.on_channel_subscribe(endpoint2, key);
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStart))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::SubAuto))));
+        assert_eq!(subscriber.pop_output(now), None);
+
+        subscriber.on_leave(endpoint1);
+        assert_eq!(subscriber.pop_output(now), None);
+        subscriber.on_leave(endpoint2);
+
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::UnsubAuto))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::PubStop))));
+        assert_eq!(subscriber.pop_output(now), Some(Output::OnResourceEmpty));
     }
 }

--- a/packages/media_core/src/cluster/room/datachannel/subscriber.rs
+++ b/packages/media_core/src/cluster/room/datachannel/subscriber.rs
@@ -1,0 +1,103 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+    hash::Hash,
+};
+
+use atm0s_sdn::features::pubsub::{self, ChannelControl, ChannelId};
+use derivative::Derivative;
+use media_server_protocol::datachannel::DataChannelPacket;
+use sans_io_runtime::{return_if_none, TaskSwitcherChild};
+
+use crate::cluster::{id_generator, ClusterEndpointEvent, ClusterRoomHash};
+
+use super::Output;
+
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
+struct ChannelContainer<Endpoint> {
+    subscribers: Vec<Endpoint>,
+    key: String,
+}
+
+pub struct DataChannelSubscriber<Endpoint> {
+    room: ClusterRoomHash,
+    channels: HashMap<ChannelId, ChannelContainer<Endpoint>>,
+    // subscribers: HashMap<Endpoint, (ChannelId, PeerId)>,
+    queue: VecDeque<Output<Endpoint>>,
+}
+
+impl<Endpoint: Hash + Eq + Copy + Debug> DataChannelSubscriber<Endpoint> {
+    pub fn new(room: ClusterRoomHash) -> Self {
+        Self {
+            room,
+            queue: VecDeque::new(),
+            channels: HashMap::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty() && self.channels.is_empty()
+    }
+
+    pub fn on_channel_subscribe(&mut self, endpoint: Endpoint, key: &str) {
+        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, endpoint, key.to_string());
+        log::info!("[ClusterRoom {}/Subscribers] peer {:?} subscribe channel: {channel_id}", self.room, endpoint);
+        let channel_container = self.channels.entry(channel_id).or_insert(ChannelContainer {
+            subscribers: vec![],
+            key: key.to_string(),
+        });
+        channel_container.subscribers.push(endpoint);
+        if channel_container.subscribers.len() == 1 {
+            log::info!("[ClusterRoom {}/Subscribers] first subscriber => Sub channel {channel_id}", self.room);
+            self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::SubAuto)));
+        }
+    }
+
+    pub fn on_channel_unsubscribe(&mut self, endpoint: Endpoint, key: &str) {
+        let channel_id: ChannelId = id_generator::gen_datachannel_id(self.room, endpoint, key.to_string());
+        log::info!("[ClusterRoom {}/Subscribers] peer {:?} unsubscribe channel: {channel_id}", self.room, endpoint);
+        if let Some(channel_container) = self.channels.get_mut(&channel_id) {
+            if let Some(index) = channel_container.subscribers.iter().position(|x| *x == endpoint) {
+                channel_container.subscribers.swap_remove(index);
+                if channel_container.subscribers.is_empty() {
+                    log::info!("[ClusterRoom {}/Subscribers] last subscriber => Unsub channel {channel_id}", self.room);
+                    self.channels.remove(&channel_id);
+                    self.queue.push_back(Output::Pubsub(pubsub::Control(channel_id, ChannelControl::UnsubAuto)));
+                }
+            } else {
+                log::warn!("[ClusterRoom {}/Subscribers] peer {:?} not subscribe in channel {channel_id}", self.room, endpoint);
+            }
+        }
+    }
+
+    pub fn on_channel_data(&mut self, channel_id: ChannelId, data: Vec<u8>) {
+        log::info!("[ClusterRoom {}/Subscribers] Receive data from channel {channel_id}", self.room);
+        let pkt = return_if_none!(DataChannelPacket::deserialize(&data));
+        if let Some(channel_container) = self.channels.get(&channel_id) {
+            for endpoint in &channel_container.subscribers {
+                self.queue.push_back(Output::Endpoint(
+                    vec![*endpoint],
+                    ClusterEndpointEvent::ChannelMessage(channel_container.key.clone(), pkt.from.clone(), pkt.data.clone()),
+                ));
+            }
+        } else {
+            log::warn!("[ClusterRoom {}/Subscribers] Receive data from unknown channel {channel_id}", self.room);
+        }
+    }
+}
+
+impl<Endpoint: Debug + Hash + Eq + Copy> TaskSwitcherChild<Output<Endpoint>> for DataChannelSubscriber<Endpoint> {
+    type Time = ();
+    fn pop_output(&mut self, _now: Self::Time) -> Option<Output<Endpoint>> {
+        self.queue.pop_front()
+    }
+}
+
+impl<Endpoint> Drop for DataChannelSubscriber<Endpoint> {
+    fn drop(&mut self) {
+        log::info!("[ClusterRoom {}/Subscriber] Drop", self.room);
+        assert_eq!(self.queue.len(), 0, "Queue not empty on drop");
+        assert_eq!(self.channels.len(), 0, "Channels not empty on drop");
+    }
+}

--- a/packages/media_core/src/cluster/room/media_track/publisher.rs
+++ b/packages/media_core/src/cluster/room/media_track/publisher.rs
@@ -82,7 +82,7 @@ impl<Endpoint: Debug + Hash + Eq + Copy> RoomChannelPublisher<Endpoint> {
 
     pub fn on_track_publish(&mut self, endpoint: Endpoint, track: RemoteTrackId, peer: PeerId, name: TrackName) {
         log::info!("[ClusterRoom {}/Publishers] peer ({peer} started track ({name})", self.room);
-        let channel_id = id_generator::gen_channel_id(self.room, &peer, &name);
+        let channel_id = id_generator::gen_track_channel_id(self.room, &peer, &name);
         self.tracks.insert((endpoint, track), (peer.clone(), name.clone(), channel_id));
         self.tracks_source.insert(channel_id, (endpoint, track));
 
@@ -140,7 +140,7 @@ mod tests {
         transport::RemoteTrackId,
     };
 
-    use super::id_generator::gen_channel_id;
+    use super::id_generator::gen_track_channel_id;
     use super::{super::Output, RoomChannelPublisher};
 
     pub fn fake_audio() -> MediaPacket {
@@ -167,7 +167,7 @@ mod tests {
         let track = RemoteTrackId(3);
         let peer = "peer1".to_string().into();
         let name = "audio_main".to_string().into();
-        let channel_id = gen_channel_id(room, &peer, &name);
+        let channel_id = gen_track_channel_id(room, &peer, &name);
         publisher.on_track_publish(endpoint, track, peer, name);
         assert_eq!(publisher.pop_output(()), Some(Output::Pubsub(Control(channel_id, ChannelControl::PubStart))));
         assert_eq!(publisher.pop_output(()), None);
@@ -194,7 +194,7 @@ mod tests {
         let track = RemoteTrackId(3);
         let peer = "peer1".to_string().into();
         let name = "audio_main".to_string().into();
-        let channel_id = gen_channel_id(room, &peer, &name);
+        let channel_id = gen_track_channel_id(room, &peer, &name);
         publisher.on_track_publish(endpoint, track, peer, name);
         assert_eq!(publisher.pop_output(()), Some(Output::Pubsub(Control(channel_id, ChannelControl::PubStart))));
         assert_eq!(publisher.pop_output(()), None);

--- a/packages/media_core/src/cluster/room/media_track/subscriber.rs
+++ b/packages/media_core/src/cluster/room/media_track/subscriber.rs
@@ -96,7 +96,7 @@ impl<Endpoint: Hash + Eq + Copy + Debug> RoomChannelSubscribe<Endpoint> {
     }
 
     pub fn on_track_subscribe(&mut self, endpoint: Endpoint, track: LocalTrackId, target_peer: PeerId, target_track: TrackName) {
-        let channel_id: ChannelId = id_generator::gen_channel_id(self.room, &target_peer, &target_track);
+        let channel_id: ChannelId = id_generator::gen_track_channel_id(self.room, &target_peer, &target_track);
         log::info!(
             "[ClusterRoom {}/Subscribers] endpoint {:?} track {track} subscribe peer {target_peer} track {target_track}), channel: {channel_id}",
             self.room,
@@ -200,7 +200,7 @@ mod tests {
         transport::LocalTrackId,
     };
 
-    use super::id_generator::gen_channel_id;
+    use super::id_generator::gen_track_channel_id;
     use super::{Output, RoomChannelSubscribe};
     use super::{BITRATE_FEEDBACK_INTERVAL, BITRATE_FEEDBACK_KIND, BITRATE_FEEDBACK_TIMEOUT, KEYFRAME_FEEDBACK_INTERVAL, KEYFRAME_FEEDBACK_KIND, KEYFRAME_FEEDBACK_TIMEOUT};
 
@@ -227,7 +227,7 @@ mod tests {
         let track = LocalTrackId(3);
         let target_peer: PeerId = "peer2".to_string().into();
         let target_track: TrackName = "audio_main".to_string().into();
-        let channel_id = gen_channel_id(room, &target_peer, &target_track);
+        let channel_id = gen_track_channel_id(room, &target_peer, &target_track);
         subscriber.on_track_subscribe(endpoint, track, target_peer.clone(), target_track.clone());
         assert_eq!(subscriber.pop_output(()), Some(Output::Pubsub(Control(channel_id, ChannelControl::SubAuto))));
         assert_eq!(subscriber.pop_output(()), None);
@@ -259,7 +259,7 @@ mod tests {
         let track = LocalTrackId(3);
         let target_peer: PeerId = "peer2".to_string().into();
         let target_track: TrackName = "audio_main".to_string().into();
-        let channel_id = gen_channel_id(room, &target_peer, &target_track);
+        let channel_id = gen_track_channel_id(room, &target_peer, &target_track);
         subscriber.on_track_subscribe(endpoint, track, target_peer.clone(), target_track.clone());
         assert_eq!(subscriber.pop_output(()), Some(Output::Pubsub(Control(channel_id, ChannelControl::SubAuto))));
         assert_eq!(subscriber.pop_output(()), None);
@@ -290,7 +290,7 @@ mod tests {
         let track1 = LocalTrackId(3);
         let target_peer: PeerId = "peer2".to_string().into();
         let target_track: TrackName = "audio_main".to_string().into();
-        let channel_id = gen_channel_id(room, &target_peer, &target_track);
+        let channel_id = gen_track_channel_id(room, &target_peer, &target_track);
         subscriber.on_track_subscribe(endpoint1, track1, target_peer.clone(), target_track.clone());
         assert_eq!(subscriber.pop_output(()), Some(Output::Pubsub(Control(channel_id, ChannelControl::SubAuto))));
         assert_eq!(subscriber.pop_output(()), None);

--- a/packages/media_core/src/endpoint.rs
+++ b/packages/media_core/src/endpoint.rs
@@ -112,6 +112,9 @@ pub enum EndpointReq {
     AudioMixer(EndpointAudioMixerReq),
     RemoteTrack(RemoteTrackId, EndpointRemoteTrackReq),
     LocalTrack(LocalTrackId, EndpointLocalTrackReq),
+    SubscribeChannel(String),
+    UnsubscribeChannel(String),
+    PublishChannel(String, String),
 }
 
 /// This is response, which is used to send response back to Endpoint SDK
@@ -124,6 +127,9 @@ pub enum EndpointRes {
     AudioMixer(EndpointAudioMixerRes),
     RemoteTrack(RemoteTrackId, EndpointRemoteTrackRes),
     LocalTrack(LocalTrackId, EndpointLocalTrackRes),
+    SubscribeChannel(RpcResult<()>),
+    UnsubscribeChannel(RpcResult<()>),
+    PublishChannel(RpcResult<()>),
 }
 
 /// This is used for controlling the local track, which is sent from endpoint
@@ -164,6 +170,9 @@ pub enum EndpointEvent {
     },
     /// This session will be disconnect after some seconds
     GoAway(u8, Option<String>),
+
+    /// DataChannel events
+    ChannelMessage(String, PeerId, String),
 }
 
 pub enum EndpointInput<Ext> {

--- a/packages/media_core/src/endpoint.rs
+++ b/packages/media_core/src/endpoint.rs
@@ -114,7 +114,7 @@ pub enum EndpointReq {
     LocalTrack(LocalTrackId, EndpointLocalTrackReq),
     SubscribeChannel(String),
     UnsubscribeChannel(String),
-    PublishChannel(String, String),
+    PublishChannel(String, Vec<u8>),
 }
 
 /// This is response, which is used to send response back to Endpoint SDK
@@ -172,7 +172,7 @@ pub enum EndpointEvent {
     GoAway(u8, Option<String>),
 
     /// DataChannel events
-    ChannelMessage(String, PeerId, String),
+    ChannelMessage(String, PeerId, Vec<u8>),
 }
 
 pub enum EndpointInput<Ext> {

--- a/packages/protocol/proto/sdk/session.proto
+++ b/packages/protocol/proto/sdk/session.proto
@@ -42,7 +42,7 @@ message Request {
         }
     }
 
-    message Rooom {
+    message Room {
         message SubscribePeer {
             string peer = 1;
         }
@@ -51,9 +51,25 @@ message Request {
             string peer = 1;
         }
 
+        message SubscribeChannel {
+            string key = 1;
+        }
+
+        message UnsubscribeChannel {
+            string key = 1;
+        }
+
+        message PublishChannel {
+            string key = 1;
+            string message = 2;
+        }
+
         oneof request {
             SubscribePeer subscribe = 1;
             UnsubscribePeer unsubscribe = 2;
+            SubscribeChannel subscribe_channel = 3;
+            UnsubscribeChannel unsubscribe_channel = 4;
+            PublishChannel publish_channel = 5;
         }
     }
 
@@ -96,7 +112,7 @@ message Request {
     uint32 req_id = 1;
     oneof request {
         Session session = 2;
-        Rooom room = 3;
+        Room room = 3;
         Sender sender = 4;
         Receiver receiver = 5;
         features.Request features = 6;
@@ -138,9 +154,24 @@ message Response {
 
         }
 
+        message SubscribeChannel {
+
+        }
+
+        message UnsubscribeChannel {
+
+        }
+
+        message PublishChannel {
+
+        }
+
         oneof response {
             SubscribePeer subscribe = 1;
             UnsubscribePeer unsubscribe = 2;
+            SubscribeChannel subscribe_channel = 3;
+            UnsubscribeChannel unsubscribe_channel = 4;
+            PublishChannel publish_channel = 5;
         }
     }
 
@@ -264,6 +295,12 @@ message ServerEvent {
             shared.Kind kind = 3;
         }
 
+        message ChannelMessage {
+            string key = 1;
+            string peer = 2;
+            string message = 3;
+        }
+
         oneof event {
             PeerJoined peer_joined = 1;
             PeerUpdated peer_updated = 2;
@@ -271,6 +308,7 @@ message ServerEvent {
             TrackStarted track_started = 4;
             TrackUpdated track_updated = 5;
             TrackStopped track_stopped = 6;
+            ChannelMessage channel_message = 7;
         }
     }
 

--- a/packages/protocol/proto/sdk/session.proto
+++ b/packages/protocol/proto/sdk/session.proto
@@ -61,7 +61,7 @@ message Request {
 
         message PublishChannel {
             string key = 1;
-            string message = 2;
+            bytes message = 2;
         }
 
         oneof request {
@@ -298,7 +298,7 @@ message ServerEvent {
         message ChannelMessage {
             string key = 1;
             string peer = 2;
-            string message = 3;
+            bytes message = 3;
         }
 
         oneof event {

--- a/packages/protocol/src/datachannel.rs
+++ b/packages/protocol/src/datachannel.rs
@@ -8,7 +8,7 @@ use crate::endpoint::PeerId;
 pub struct DataChannelPacket {
     pub from: PeerId,
     #[derivative(Debug = "ignore")]
-    pub data: String,
+    pub data: Vec<u8>,
 }
 impl DataChannelPacket {
     pub fn serialize(&self) -> Vec<u8> {

--- a/packages/protocol/src/datachannel.rs
+++ b/packages/protocol/src/datachannel.rs
@@ -1,0 +1,21 @@
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+
+use crate::endpoint::PeerId;
+
+#[derive(Derivative, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derivative(Debug)]
+pub struct DataChannelPacket {
+    pub from: PeerId,
+    #[derivative(Debug = "ignore")]
+    pub data: String,
+}
+impl DataChannelPacket {
+    pub fn serialize(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("should ok")
+    }
+
+    pub fn deserialize(data: &[u8]) -> Option<DataChannelPacket> {
+        bincode::deserialize::<Self>(data).ok()
+    }
+}

--- a/packages/protocol/src/lib.rs
+++ b/packages/protocol/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cluster;
 pub mod connector;
+pub mod datachannel;
 pub mod endpoint;
 pub mod gateway;
 pub mod media;

--- a/packages/protocol/src/protobuf/session.rs
+++ b/packages/protocol/src/protobuf/session.rs
@@ -105,8 +105,8 @@ pub mod request {
         pub struct PublishChannel {
             #[prost(string, tag = "1")]
             pub key: ::prost::alloc::string::String,
-            #[prost(string, tag = "2")]
-            pub message: ::prost::alloc::string::String,
+            #[prost(bytes = "vec", tag = "2")]
+            pub message: ::prost::alloc::vec::Vec<u8>,
         }
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -504,8 +504,8 @@ pub mod server_event {
             pub key: ::prost::alloc::string::String,
             #[prost(string, tag = "2")]
             pub peer: ::prost::alloc::string::String,
-            #[prost(string, tag = "3")]
-            pub message: ::prost::alloc::string::String,
+            #[prost(bytes = "vec", tag = "3")]
+            pub message: ::prost::alloc::vec::Vec<u8>,
         }
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]

--- a/packages/protocol/src/protobuf/session.rs
+++ b/packages/protocol/src/protobuf/session.rs
@@ -70,12 +70,12 @@ pub mod request {
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct Rooom {
-        #[prost(oneof = "rooom::Request", tags = "1, 2")]
-        pub request: ::core::option::Option<rooom::Request>,
+    pub struct Room {
+        #[prost(oneof = "room::Request", tags = "1, 2, 3, 4, 5")]
+        pub request: ::core::option::Option<room::Request>,
     }
-    /// Nested message and enum types in `Rooom`.
-    pub mod rooom {
+    /// Nested message and enum types in `Room`.
+    pub mod room {
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct SubscribePeer {
@@ -89,12 +89,38 @@ pub mod request {
             pub peer: ::prost::alloc::string::String,
         }
         #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct SubscribeChannel {
+            #[prost(string, tag = "1")]
+            pub key: ::prost::alloc::string::String,
+        }
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct UnsubscribeChannel {
+            #[prost(string, tag = "1")]
+            pub key: ::prost::alloc::string::String,
+        }
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct PublishChannel {
+            #[prost(string, tag = "1")]
+            pub key: ::prost::alloc::string::String,
+            #[prost(string, tag = "2")]
+            pub message: ::prost::alloc::string::String,
+        }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Request {
             #[prost(message, tag = "1")]
             Subscribe(SubscribePeer),
             #[prost(message, tag = "2")]
             Unsubscribe(UnsubscribePeer),
+            #[prost(message, tag = "3")]
+            SubscribeChannel(SubscribeChannel),
+            #[prost(message, tag = "4")]
+            UnsubscribeChannel(UnsubscribeChannel),
+            #[prost(message, tag = "5")]
+            PublishChannel(PublishChannel),
         }
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -175,7 +201,7 @@ pub mod request {
         #[prost(message, tag = "2")]
         Session(Session),
         #[prost(message, tag = "3")]
-        Room(Rooom),
+        Room(Room),
         #[prost(message, tag = "4")]
         Sender(Sender),
         #[prost(message, tag = "5")]
@@ -233,7 +259,7 @@ pub mod response {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Room {
-        #[prost(oneof = "room::Response", tags = "1, 2")]
+        #[prost(oneof = "room::Response", tags = "1, 2, 3, 4, 5")]
         pub response: ::core::option::Option<room::Response>,
     }
     /// Nested message and enum types in `Room`.
@@ -245,12 +271,27 @@ pub mod response {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct UnsubscribePeer {}
         #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct SubscribeChannel {}
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct UnsubscribeChannel {}
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct PublishChannel {}
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Response {
             #[prost(message, tag = "1")]
             Subscribe(SubscribePeer),
             #[prost(message, tag = "2")]
             Unsubscribe(UnsubscribePeer),
+            #[prost(message, tag = "3")]
+            SubscribeChannel(SubscribeChannel),
+            #[prost(message, tag = "4")]
+            UnsubscribeChannel(UnsubscribeChannel),
+            #[prost(message, tag = "5")]
+            PublishChannel(PublishChannel),
         }
     }
     #[allow(clippy::derive_partial_eq_without_eq)]
@@ -395,7 +436,7 @@ pub mod server_event {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Room {
-        #[prost(oneof = "room::Event", tags = "1, 2, 3, 4, 5, 6")]
+        #[prost(oneof = "room::Event", tags = "1, 2, 3, 4, 5, 6, 7")]
         pub event: ::core::option::Option<room::Event>,
     }
     /// Nested message and enum types in `Room`.
@@ -457,6 +498,16 @@ pub mod server_event {
             pub kind: i32,
         }
         #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct ChannelMessage {
+            #[prost(string, tag = "1")]
+            pub key: ::prost::alloc::string::String,
+            #[prost(string, tag = "2")]
+            pub peer: ::prost::alloc::string::String,
+            #[prost(string, tag = "3")]
+            pub message: ::prost::alloc::string::String,
+        }
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Event {
             #[prost(message, tag = "1")]
@@ -471,6 +522,8 @@ pub mod server_event {
             TrackUpdated(TrackUpdated),
             #[prost(message, tag = "6")]
             TrackStopped(TrackStopped),
+            #[prost(message, tag = "7")]
+            ChannelMessage(ChannelMessage),
         }
     }
     #[allow(clippy::derive_partial_eq_without_eq)]

--- a/packages/transport_webrtc/src/transport/webrtc.rs
+++ b/packages/transport_webrtc/src/transport/webrtc.rs
@@ -349,7 +349,7 @@ impl<ES: MediaEdgeSecure> TransportWebrtcInternal for TransportWebrtcSdk<ES> {
             EndpointEvent::ChannelMessage(key, from, message) => {
                 log::info!("[TransportWebrtcSdk] datachannel message {key}");
                 self.send_event(ProtoServerEvent::Room(ProtoRoomEvent {
-                    event: Some(ProtoRoomEvent2::ChannelMessage(ChannelMessage { key, peer: from.0, message: message })),
+                    event: Some(ProtoRoomEvent2::ChannelMessage(ChannelMessage { key, peer: from.0, message })),
                 }))
             }
             EndpointEvent::GoAway(_, _) => {}
@@ -833,7 +833,7 @@ impl<ES: MediaEdgeSecure> TransportWebrtcSdk<ES> {
             protobuf::session::request::room::Request::PublishChannel(req) => {
                 self.queue.push_back(InternalOutput::TransportOutput(TransportOutput::RpcReq(
                     req_id.into(),
-                    EndpointReq::PublishChannel(req.key, req.message.into()),
+                    EndpointReq::PublishChannel(req.key, req.message),
                 )));
             }
             _ => {

--- a/packages/transport_webrtc/src/transport/whep.rs
+++ b/packages/transport_webrtc/src/transport/whep.rs
@@ -161,6 +161,7 @@ impl TransportWebrtcInternal for TransportWebrtcWhep {
             }
             EndpointEvent::GoAway(_seconds, _reason) => {}
             EndpointEvent::AudioMixer(_) => {}
+            EndpointEvent::ChannelMessage(..) => {}
         }
     }
 

--- a/packages/transport_webrtc/src/transport/whip.rs
+++ b/packages/transport_webrtc/src/transport/whip.rs
@@ -138,6 +138,7 @@ impl TransportWebrtcInternal for TransportWebrtcWhip {
             EndpointEvent::BweConfig { .. } => {}
             EndpointEvent::GoAway(_, _) => {}
             EndpointEvent::AudioMixer(_) => {}
+            EndpointEvent::ChannelMessage(..) => {}
         }
     }
 


### PR DESCRIPTION
## Pull Request

### Description

Added a virtual datachannel for bi-direction communication between the users in a room. This datachannel is not the same with the WebRTC Datachannel, but it will use the WebRTC Channel to transports the pubsub style messages.
A virtual datachannel can be created dynamically via Room Request through the SDK. A Room can have multiple virtual channels.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.
