### PR TITLE
Fix: build release with c++ deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,9 @@ jobs:
 
       - name: Install dev-tools
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y --no-install-recommends pkg-config musl-dev musl-tools
+        run: |
+          sudo apt-get install -y --no-install-recommends pkg-config musl-dev musl-tools
+          sudo ln -s /bin/g++ /bin/musl-g++
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Pull Request

### Description

This PR fixed build release failed caused by missing musl-c++

### Related Issue

Github Actions build release failed

### Checklist

- [x] I have tested the changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added appropriate tests, if applicable.