### PR TITLE
ci: fix clippy actions workflow and add cargo-fmt action

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -33,10 +33,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      # Install protobuf-compiler (protoc)
-      - name: Install Protobuf Compiler
-        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "25.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}     
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -1,9 +1,15 @@
+# rust-clippy is a tool that runs a bunch of lints to catch common
+# mistakes in your Rust code and help improve your Rust code.
+# More details at https://github.com/rust-lang/rust-clippy
+# and https://rust-lang.github.io/rust-clippy/
+
 name: rust-clippy analyze
 
 on:
   push:
     branches: [ "master" ]
   pull_request:
+    # The branches below must be a subset of the branches above
     branches: [ "master" ]
   schedule:
     - cron: '29 19 * * 2'
@@ -22,7 +28,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      actions: read
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -37,14 +37,6 @@ jobs:
       # Install protobuf-compiler (protoc)
       - name: Install Protobuf Compiler
         run: sudo apt-get install -y protobuf-compiler
-        
-      - name: Configure cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -37,7 +37,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      # Install protobuf-compiler (protoc)
+      - name: Install Protobuf Compiler
+        run: sudo apt-get install -y protobuf-compiler
 
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+        
       - name: Configure cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -46,7 +46,7 @@ jobs:
           cargo clippy
           --all-features
           --message-format=json 
-          --all-targets -- -D warnings | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          --all-targets | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -1,21 +1,14 @@
-# rust-clippy is a tool that runs a bunch of lints to catch common
-# mistakes in your Rust code and help improve your Rust code.
-# More details at https://github.com/rust-lang/rust-clippy
-# and https://rust-lang.github.io/rust-clippy/
-
 name: rust-clippy analyze
 
 on:
   push:
     branches: [ "master" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "master" ]
   schedule:
     - cron: '29 19 * * 2'
 
 concurrency:
-  # One build per PR, branch or tag
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -29,7 +22,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -48,17 +41,24 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "25.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}     
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
 
       - name: Run rust-clippy
-        run:
-          cargo clippy
-          --all-features
-          --message-format=json 
-          --all-targets | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        run: |
+          set -o pipefail
+          cargo clippy --all-targets --all-features --message-format=json |
+          clippy-sarif > rust-clippy-results.sarif
+          CLIPPY_EXIT_STATUS=${PIPESTATUS[0]}
+          if [ "$CLIPPY_EXIT_STATUS" -ne 0 ]; then
+            echo "Clippy found issues."
+            exit $CLIPPY_EXIT_STATUS
+          fi
+
+      - name: Format SARIF file
+        run: sarif-fmt rust-clippy-results.sarif
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -18,6 +18,14 @@ on:
   schedule:
     - cron: '29 19 * * 2'
 
+concurrency:
+  # One build per PR, branch or tag
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   rust-clippy-analyze:
     name: Run rust-clippy analyzing
@@ -30,13 +38,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
+      - name: Configure cache
+        uses: actions/cache@v3
         with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-          override: true
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+        continue-on-error: true
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
@@ -45,7 +57,8 @@ jobs:
         run:
           cargo clippy
           --all-features
-          --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          --message-format=json 
+          --all-targets -- -D warnings | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
 
       - name: Upload analysis results to GitHub

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -28,37 +28,30 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: actions/cache@v3
+        id: cache-cargo
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
           version: "25.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Run rust-clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
 
-      - name: Run rust-clippy
-        run: |
-          set -o pipefail
-          cargo clippy --all-targets --all-features --message-format=json |
-          clippy-sarif > rust-clippy-results.sarif
-          CLIPPY_EXIT_STATUS=${PIPESTATUS[0]}
-          if [ "$CLIPPY_EXIT_STATUS" -ne 0 ]; then
-            echo "Clippy found issues."
-            exit $CLIPPY_EXIT_STATUS
-          fi
-
-      - name: Format SARIF file
-        run: sarif-fmt rust-clippy-results.sarif
+      - name: Run rust-sarif
+        run: cargo clippy --all-features --message-format=json | 
+          clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -18,8 +18,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust-clippy-analyze:
-    name: Run rust-clippy analyzing
+  rust-fmt-analyze:
+    name: Run rust-fmt analyzing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -29,14 +29,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Configure cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-${{ hashFiles('**/Cargo.toml') }}
-
       - name: cargo fmt
         run: cargo fmt --all -- --check
         continue-on-error: true

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -21,10 +21,6 @@ jobs:
   rust-fmt-analyze:
     name: Run rust-fmt analyzing
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -31,4 +31,3 @@ jobs:
       
       - name: cargo fmt
         run: cargo fmt --all -- --check
-        continue-on-error: true

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -1,9 +1,4 @@
-# rust-clippy is a tool that runs a bunch of lints to catch common
-# mistakes in your Rust code and help improve your Rust code.
-# More details at https://github.com/rust-lang/rust-clippy
-# and https://rust-lang.github.io/rust-clippy/
-
-name: rust-clippy analyze
+name: rust-fmt analyze
 
 on:
   push:
@@ -34,10 +29,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      # Install protobuf-compiler (protoc)
-      - name: Install Protobuf Compiler
-        run: sudo apt-get install -y protobuf-compiler
-        
       - name: Configure cache
         uses: actions/cache@v3
         with:
@@ -46,18 +37,6 @@ jobs:
             ~/.cargo/git
           key: cargo-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Install required cargo
-        run: cargo install clippy-sarif sarif-fmt
-
-      - name: Run rust-clippy
-        run:
-          cargo clippy
-          --all-features
-          --message-format=json 
-          --all-targets -- -D warnings | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
-
-      - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: rust-clippy-results.sarif
-          wait-for-processing: true
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+        continue-on-error: true

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -29,5 +29,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: cargo fmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install -y libsoxr-dev libopus-dev libssl-dev libfdk-aac-dev
-      - name: Install Rust
-        run: rustup update stable
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/bin/src/http.rs
+++ b/bin/src/http.rs
@@ -8,8 +8,6 @@ use media_server_protocol::protobuf::cluster_connector::MediaConnectorServiceCli
 use media_server_protocol::rpc::quinn::{QuinnClient, QuinnStream};
 use media_server_protocol::transport::{RpcReq, RpcRes};
 use media_server_secure::{MediaEdgeSecure, MediaGatewaySecure};
-#[cfg(feature = "embed_static")]
-use utils::EmbeddedFilesEndpoint;
 #[cfg(not(feature = "embed_static"))]
 use poem::endpoint::StaticFilesEndpoint;
 use poem::{listener::TcpListener, middleware::Cors, EndpointExt, Route, Server};
@@ -17,6 +15,8 @@ use poem_openapi::types::{ToJSON, Type};
 use poem_openapi::OpenApiService;
 use poem_openapi::{types::ParseFromJSON, Object};
 use tokio::sync::mpsc::Sender;
+#[cfg(feature = "embed_static")]
+use utils::EmbeddedFilesEndpoint;
 
 mod api_connector;
 mod api_console;

--- a/packages/media_core/src/cluster.rs
+++ b/packages/media_core/src/cluster.rs
@@ -33,7 +33,7 @@ pub struct ClusterRoomHash(pub u64);
 
 impl From<&RoomId> for ClusterRoomHash {
     fn from(room: &RoomId) -> Self {
-        let mut hash = std::hash::DefaultHasher::new();
+    let mut hash = std::hash::DefaultHasher::new();
         room.as_ref().hash(&mut hash);
         Self(hash.finish())
     }

--- a/packages/media_core/src/cluster.rs
+++ b/packages/media_core/src/cluster.rs
@@ -33,7 +33,7 @@ pub struct ClusterRoomHash(pub u64);
 
 impl From<&RoomId> for ClusterRoomHash {
     fn from(room: &RoomId) -> Self {
-    let mut hash = std::hash::DefaultHasher::new();
+        let mut hash = std::hash::DefaultHasher::new();
         room.as_ref().hash(&mut hash);
         Self(hash.finish())
     }

--- a/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp8_sim.rs
+++ b/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp8_sim.rs
@@ -254,6 +254,7 @@ mod tests {
         res
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn video_pkt(seq: u16, ts: u32, key: bool, layers: Option<&[[u16; 3]]>, spatial: u8, temporal: u8, layer_sync: bool, tl0idx: u8, pic_id: u16) -> MediaPacket {
         MediaPacket {
             ts,

--- a/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp9_svc.rs
+++ b/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp9_svc.rs
@@ -268,6 +268,7 @@ mod tests {
         res
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn video_pkt(seq: u16, ts: u32, key: bool, layers: Option<&[[u16; 3]]>, spatial: u8, temporal: u8, switching_point: bool, end_frame: bool, pic_id: u16) -> MediaPacket {
         MediaPacket {
             ts,

--- a/packages/media_record/src/storage/disk.rs
+++ b/packages/media_record/src/storage/disk.rs
@@ -154,8 +154,8 @@ mod test {
         let storage = DiskStorage::new("/tmp/");
 
         let mut mem_file = MemoryFile::default();
-        mem_file.write(&[1, 2, 3, 4]).await.expect("should write");
-        mem_file.write(&[5, 6, 7, 8, 9]).await.expect("should write");
+        mem_file.write_all(&[1, 2, 3, 4]).await.expect("should write");
+        mem_file.write_all(&[5, 6, 7, 8, 9]).await.expect("should write");
 
         let mut file = storage.copy_from_mem(mem_file).await.expect("Should create file");
 

--- a/packages/media_record/src/storage/memory.rs
+++ b/packages/media_record/src/storage/memory.rs
@@ -159,8 +159,8 @@ mod test {
         use std::io::Write;
 
         let mut file = MemoryFile::default();
-        file.write(&[1, 2, 3, 4]).expect("should write");
-        file.write(&[5, 6, 7, 8, 9]).expect("should write");
+        file.write_all(&[1, 2, 3, 4]).expect("should write");
+        file.write_all(&[5, 6, 7, 8, 9]).expect("should write");
 
         let mut buf = [0; 10];
         let len = file.read(&mut buf).await.unwrap();
@@ -177,8 +177,8 @@ mod test {
         use tokio::io::AsyncWriteExt;
 
         let mut file = MemoryFile::default();
-        file.write(&[1, 2, 3, 4]).await.expect("should write");
-        file.write(&[5, 6, 7, 8, 9]).await.expect("should write");
+        file.write_all(&[1, 2, 3, 4]).await.expect("should write");
+        file.write_all(&[5, 6, 7, 8, 9]).await.expect("should write");
 
         let mut buf = [0; 10];
         let len = file.read(&mut buf).await.unwrap();

--- a/packages/media_utils/src/f16.rs
+++ b/packages/media_utils/src/f16.rs
@@ -32,7 +32,7 @@ pub struct F16i(i16);
 
 impl From<F16i> for f32 {
     fn from(val: F16i) -> Self {
-         val.0 as f32 / 100.0
+        val.0 as f32 / 100.0
     }
 }
 

--- a/packages/protocol/build.rs
+++ b/packages/protocol/build.rs
@@ -28,6 +28,7 @@ fn main() -> Result<()> {
         .type_attribute("cluster_connector.PeerEvent.LocalTrack", "#[derive(serde::Serialize)]")
         .type_attribute("cluster_connector.PeerEvent.LocalTrackAttach", "#[derive(serde::Serialize)]")
         .type_attribute("cluster_connector.PeerEvent.LocalTrackDetach", "#[derive(serde::Serialize)]")
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &[
                 "./proto/shared.proto",

--- a/packages/transport_webrtc/src/media/vp8.rs
+++ b/packages/transport_webrtc/src/media/vp8.rs
@@ -99,7 +99,6 @@ pub fn parse_rtp(packet: &[u8], rid: Option<u8>) -> Option<MediaMeta> {
     }
 }
 
-#[allow(unused_assignments)]
 pub fn rewrite_rtp(payload: &mut [u8], sim: &Vp8Sim) {
     let mut payload_index = 0;
 

--- a/packages/transport_webrtc/src/media/vp8.rs
+++ b/packages/transport_webrtc/src/media/vp8.rs
@@ -129,6 +129,7 @@ pub fn rewrite_rtp(payload: &mut [u8], sim: &Vp8Sim) {
         }
     }
 
+    #[allow(unused_assignments)]
     if l == 1 {
         payload[payload_index] = sim.tl0_pic_idx.unwrap_or(0);
         payload_index += 1;


### PR DESCRIPTION
Clippy was already being used. But it never reported any problems. The errors were always suppressed because we were piping the clippy output to cargo-sarif. This piping masked the exit code of clippy command. Which is why you might notice clippy is run twice now.

Note: actions-rs was deprecated and archived because GH Actions now support for rust by default: https://github.com/actions/starter-workflows/blob/main/ci/rust.yml

Apart from this, I have also added a cargo fmt action, added cache support and fixed remaining clippy warnings.

CC: @giangndm: https://github.com/8xFF/atm0s-media-server/pull/349#issuecomment-2232288594

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.