### PR TITLE
Feat graceful disconnect webrtc

### DIFF
--- a/packages/media_core/src/endpoint.rs
+++ b/packages/media_core/src/endpoint.rs
@@ -171,7 +171,6 @@ pub enum EndpointInput<Ext> {
     Net(BackendIncoming),
     Cluster(ClusterEndpointEvent),
     Ext(Ext),
-    Close,
 }
 
 pub enum EndpointOutput<Ext> {
@@ -238,14 +237,11 @@ where
             EndpointInput::Cluster(event) => {
                 self.internal.input(&mut self.switcher).on_cluster_event(now, event);
             }
-            EndpointInput::Close => {
-                self.transport.input(&mut self.switcher).on_input(now, TransportInput::Close);
-            }
         }
     }
 
     fn on_shutdown(&mut self, now: Instant) {
-        self.transport.input(&mut self.switcher).on_input(now, TransportInput::Close);
+        self.transport.input(&mut self.switcher).on_input(now, TransportInput::SystemClose);
     }
 }
 

--- a/packages/media_core/src/transport.rs
+++ b/packages/media_core/src/transport.rs
@@ -93,7 +93,7 @@ pub enum TransportInput<Ext> {
     Endpoint(EndpointEvent),
     RpcRes(EndpointReqId, EndpointRes),
     Ext(Ext),
-    Close,
+    SystemClose,
 }
 
 /// This is event from transport, in general is is result of transport protocol

--- a/packages/transport_webrtc/src/transport.rs
+++ b/packages/transport_webrtc/src/transport.rs
@@ -332,7 +332,6 @@ impl<ES: 'static + MediaEdgeSecure> Transport<ExtIn, ExtOut> for TransportWebrtc
             },
             TransportInput::SystemClose => {
                 log::info!("[TransportWebrtc] system close request");
-                self.rtc.disconnect();
                 self.internal.close(now);
             }
         }

--- a/packages/transport_webrtc/src/transport.rs
+++ b/packages/transport_webrtc/src/transport.rs
@@ -61,6 +61,7 @@ pub enum ExtIn {
     RemoteIce(u64, Variant, Vec<String>),
     /// Last option<string>, bool is userdata and record flag
     RestartIce(u64, Variant, IpAddr, String, ConnectRequest, Option<String>, bool),
+    Disconnect(u64, Variant),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -68,6 +69,7 @@ pub enum ExtOut {
     RemoteIce(u64, Variant, RpcResult<u32>),
     /// response is (ice_lite, answer_sdp)
     RestartIce(u64, Variant, RpcResult<(bool, String)>),
+    Disconnect(u64, Variant, RpcResult<()>),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -323,9 +325,13 @@ impl<ES: 'static + MediaEdgeSecure> Transport<ExtIn, ExtOut> for TransportWebrtc
                             .push_back(TransportOutput::Ext(ExtOut::RestartIce(req_id, variant, Err(RpcError::new2(WebrtcError::InvalidSdp)))));
                     }
                 }
+                ExtIn::Disconnect(req_id, variant) => {
+                    self.internal.close(now);
+                    self.queue.push_back(TransportOutput::Ext(ExtOut::Disconnect(req_id, variant, Ok(()))));
+                }
             },
-            TransportInput::Close => {
-                log::info!("[TransportWebrtc] close request");
+            TransportInput::SystemClose => {
+                log::info!("[TransportWebrtc] system close request");
                 self.rtc.disconnect();
                 self.internal.close(now);
             }

--- a/packages/transport_webrtc/src/worker.rs
+++ b/packages/transport_webrtc/src/worker.rs
@@ -35,7 +35,6 @@ pub enum GroupInput {
     Net(BackendIncoming),
     Cluster(WebrtcSession, ClusterEndpointEvent),
     Ext(WebrtcSession, ExtIn),
-    Close(WebrtcSession),
 }
 
 #[derive(Debug)]
@@ -165,11 +164,12 @@ impl<ES: MediaEdgeSecure> MediaWorkerWebrtc<ES> {
                                     .push_back(GroupOutput::Ext(owner, ExtOut::RestartIce(req_id, variant, Err(RpcError::new2(WebrtcError::RpcEndpointNotFound)))));
                             }
                         }
+                        ExtIn::Disconnect(req_id, variant) => {
+                            self.queue
+                                .push_back(GroupOutput::Ext(owner, ExtOut::Disconnect(req_id, variant, Err(RpcError::new2(WebrtcError::RpcEndpointNotFound)))));
+                        }
                     }
                 }
-            }
-            GroupInput::Close(owner) => {
-                self.endpoints.on_event(now, owner.index(), EndpointInput::Close);
             }
         }
     }


### PR DESCRIPTION
## Pull Request

### Description

This PR add graceful disconnect for webrtc connections. incoming request waits for internal endpoint destroyed before response to client

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
