### PR TITLE
fixed: missing config connector agent service which caused missing peer logs

### DIFF
--- a/packages/media_runner/src/worker.rs
+++ b/packages/media_runner/src/worker.rs
@@ -191,7 +191,7 @@ impl<ES: 'static + MediaEdgeSecure> MediaServerWorker<ES> {
             tick_ms: 1000,
             data: DataPlaneCfg {
                 worker_id: 0,
-                services: vec![visualization, discovery, gateway],
+                services: vec![visualization, discovery, gateway, connector],
                 history,
             },
         };


### PR DESCRIPTION
## Pull Request

### Description

This PR fixed missing peer logs issue.
The main reason is config for connector agent is only set for controller thread, not worker thread.

https://github.com/8xFF/atm0s-media-server/blob/9b1403b1eecef5faf000eb9820b8022d2a1da53f/packages/media_runner/src/worker.rs#L176-L197

(at line 194 we missed "connector")

This only occurred after we have some optimized by avoiding internal event re-router to controller then back to worker.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added appropriate tests, if applicable.
