### PR TITLE
fixed: route restart-ice to other media node if current down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
  "atm0s-sdn",
  "log",
  "media-server-protocol",
+ "media-server-utils",
  "prost",
  "serde",
 ]

--- a/bin/media_z0_n2.sh
+++ b/bin/media_z0_n2.sh
@@ -9,4 +9,5 @@ cargo run -- \
     --seeds 1@/ip4/127.0.0.1/udp/10001 \
     --workers 2 \
     media \
+        --webrtc-port-seed 10200 \
         --enable-token-api

--- a/bin/media_z0_n3.sh
+++ b/bin/media_z0_n3.sh
@@ -9,4 +9,5 @@ cargo run -- \
     --seeds 1@/ip4/127.0.0.1/udp/10001 \
     --workers 2 \
     media \
+        --webrtc-port-seed 10300 \
         --enable-token-api

--- a/bin/media_z256_n1.sh
+++ b/bin/media_z256_n1.sh
@@ -9,4 +9,5 @@ cargo run -- \
     --seeds 256@/ip4/127.0.0.1/udp/11000 \
     --workers 2 \
     media \
+        --webrtc-port-seed 11200 \
         --enable-token-api

--- a/bin/media_z256_n2.sh
+++ b/bin/media_z256_n2.sh
@@ -9,4 +9,5 @@ cargo run -- \
     --seeds 256@/ip4/127.0.0.1/udp/11000 \
     --workers 2 \
     media \
+        --webrtc-port-seed 11300 \
         --enable-token-api

--- a/bin/src/errors.rs
+++ b/bin/src/errors.rs
@@ -6,4 +6,5 @@ pub enum MediaServerError {
     NodePoolEmpty = 0x00020003,
     MediaResError = 0x00020004,
     NotImplemented = 0x00020005,
+    NodeTimeout = 0x00020006,
 }

--- a/bin/src/server/gateway.rs
+++ b/bin/src/server/gateway.rs
@@ -241,6 +241,7 @@ pub async fn run_media_gateway(workers: usize, http_port: Option<u16>, node: Nod
                         max_sessions = max;
                     }
                     media_server_gateway::store_service::Event::FindNodeRes(req_id, res) => requester.on_find_node_res(req_id, res),
+                    media_server_gateway::store_service::Event::FindDestRes(req_id, res) => requester.on_find_dest_res(req_id, res),
                 },
                 SdnExtOut::ServicesEvent(_, _, SE::Connector(event)) => match event {
                     media_server_connector::agent_service::Event::Stats { queue: _, inflight: _, acked: _ } => {}

--- a/bin/src/server/gateway/dest_selector.rs
+++ b/bin/src/server/gateway/dest_selector.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use atm0s_sdn::NodeId;
 use media_server_gateway::ServiceKind;
 use media_server_protocol::protobuf::cluster_gateway::ping_event::gateway_origin::Location;
 use tokio::sync::{
@@ -7,7 +8,10 @@ use tokio::sync::{
     oneshot,
 };
 
-type QueryRequest = (ServiceKind, Option<(f32, f32)>, oneshot::Sender<Option<u32>>);
+enum QueryRequest {
+    Select(ServiceKind, Option<(f32, f32)>, oneshot::Sender<Option<NodeId>>),
+    DestFor(ServiceKind, NodeId, oneshot::Sender<Option<NodeId>>),
+}
 
 #[derive(Clone)]
 pub struct GatewayDestSelector {
@@ -15,9 +19,19 @@ pub struct GatewayDestSelector {
 }
 
 impl GatewayDestSelector {
-    pub async fn select(&self, kind: ServiceKind, location: Option<(f32, f32)>) -> Option<u32> {
+    /// Select best destination, it can be media-node or other gateway node
+    pub async fn select(&self, kind: ServiceKind, location: Option<(f32, f32)>) -> Option<NodeId> {
         let (tx, rx) = oneshot::channel();
-        self.tx.send((kind, location, tx)).await.ok()?;
+        self.tx.send(QueryRequest::Select(kind, location, tx)).await.ok()?;
+        rx.await.ok()?
+    }
+
+    /// Find forward dest if we need to send request to a node.
+    /// if node is in current zone, then return Some(node) if it avaiable
+    /// if node in other zone, return the zone gateway node
+    pub async fn dest_for(&self, kind: ServiceKind, node: NodeId) -> Option<NodeId> {
+        let (tx, rx) = oneshot::channel();
+        self.tx.send(QueryRequest::DestFor(kind, node, tx)).await.ok()?;
         rx.await.ok()?
     }
 }
@@ -37,16 +51,33 @@ impl GatewayDestRequester {
         }
     }
 
+    pub fn on_find_dest_res(&mut self, req_id: u64, res: Option<u32>) {
+        if let Some(tx) = self.reqs.remove(&req_id) {
+            if tx.send(res).is_err() {
+                log::error!("[GatewayDestRequester] answer for req_id {req_id} error");
+            }
+        }
+    }
+
     pub fn recv(&mut self) -> Option<media_server_gateway::store_service::Control> {
-        let (kind, location, tx) = self.rx.try_recv().ok()?;
-        let req_id = self.req_seed;
-        self.req_seed += 1;
-        self.reqs.insert(req_id, tx);
-        Some(media_server_gateway::store_service::Control::FindNodeReq(
-            req_id,
-            kind,
-            location.map(|(lat, lon)| Location { lat, lon }),
-        ))
+        match self.rx.try_recv().ok()? {
+            QueryRequest::Select(kind, location, tx) => {
+                let req_id = self.req_seed;
+                self.req_seed += 1;
+                self.reqs.insert(req_id, tx);
+                Some(media_server_gateway::store_service::Control::FindNodeReq(
+                    req_id,
+                    kind,
+                    location.map(|(lat, lon)| Location { lat, lon }),
+                ))
+            }
+            QueryRequest::DestFor(kind, dest, tx) => {
+                let req_id = self.req_seed;
+                self.req_seed += 1;
+                self.reqs.insert(req_id, tx);
+                Some(media_server_gateway::store_service::Control::FindDestReq(req_id, kind, dest))
+            }
+        }
     }
 }
 

--- a/bin/src/server/gateway/dest_selector.rs
+++ b/bin/src/server/gateway/dest_selector.rs
@@ -27,7 +27,7 @@ impl GatewayDestSelector {
     }
 
     /// Find forward dest if we need to send request to a node.
-    /// if node is in current zone, then return Some(node) if it avaiable
+    /// if node is in current zone, then return Some(node) if it available
     /// if node in other zone, return the zone gateway node
     pub async fn dest_for(&self, kind: ServiceKind, node: NodeId) -> Option<NodeId> {
         let (tx, rx) = oneshot::channel();

--- a/packages/media_gateway/Cargo.toml
+++ b/packages/media_gateway/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2021"
 log = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 media-server-protocol = { path = "../protocol" }
+media-server-utils = { path = "../media_utils" }
 atm0s-sdn = { workspace = true }
 prost = { workspace = true }

--- a/packages/media_gateway/src/store.rs
+++ b/packages/media_gateway/src/store.rs
@@ -1,3 +1,4 @@
+use atm0s_sdn::NodeId;
 use media_server_protocol::protobuf::cluster_gateway::ping_event::{gateway_origin::Location, GatewayOrigin, Origin, ServiceStats};
 
 use crate::{NodeMetrics, ServiceKind};
@@ -32,8 +33,8 @@ impl GatewayStore {
     pub fn new(zone: u32, location: Location, max_cpu: u8, max_memory: u8, max_disk: u8) -> Self {
         Self {
             node: NodeMetrics::default(),
-            webrtc: ServiceStore::new(ServiceKind::Webrtc, location),
-            rtpengine: ServiceStore::new(ServiceKind::RtpEngine, location),
+            webrtc: ServiceStore::new(zone, ServiceKind::Webrtc, location),
+            rtpengine: ServiceStore::new(zone, ServiceKind::RtpEngine, location),
             zone,
             location,
             output: None,
@@ -101,12 +102,21 @@ impl GatewayStore {
         }
     }
 
-    pub fn best_for(&self, kind: ServiceKind, location: Option<Location>) -> Option<u32> {
+    pub fn best_for(&self, kind: ServiceKind, location: Option<Location>) -> Option<NodeId> {
         let node = match kind {
             ServiceKind::Webrtc => self.webrtc.best_for(location),
             ServiceKind::RtpEngine => self.rtpengine.best_for(location),
         };
         log::debug!("[GatewayStore] query best {:?} for {:?} got {:?}", kind, location, node);
+        node
+    }
+
+    pub fn dest_for(&self, kind: ServiceKind, dest: NodeId) -> Option<NodeId> {
+        let node = match kind {
+            ServiceKind::Webrtc => self.webrtc.dest_for(dest),
+            ServiceKind::RtpEngine => self.rtpengine.dest_for(dest),
+        };
+        log::debug!("[GatewayStore] query dest {:?} for node {} got {:?}", kind, dest, node);
         node
     }
 

--- a/packages/media_gateway/src/store/service.rs
+++ b/packages/media_gateway/src/store/service.rs
@@ -158,7 +158,7 @@ impl ServiceStore {
     }
 
     /// If we in same zone then only check local registry
-    /// Else we forward it to the zone gateway if avaiable
+    /// Else we forward it to the zone gateway if available
     pub fn dest_for(&self, dest: NodeId) -> Option<u32> {
         if node_zone_id(dest) == self.zone {
             for n in self.local_sources.iter() {

--- a/packages/media_utils/src/lib.rs
+++ b/packages/media_utils/src/lib.rs
@@ -1,4 +1,5 @@
 mod f16;
+mod sdn;
 mod select;
 mod seq_extend;
 mod seq_rewrite;
@@ -8,6 +9,7 @@ mod ts_rewrite;
 mod uri;
 
 pub use f16::{F16i, F16u};
+pub use sdn::*;
 pub use select::*;
 pub use seq_extend::RtpSeqExtend;
 pub use seq_rewrite::SeqRewrite;

--- a/packages/media_utils/src/sdn.rs
+++ b/packages/media_utils/src/sdn.rs
@@ -1,0 +1,3 @@
+pub fn node_zone_id(node: u32) -> u32 {
+    node & 0xFFFFFF00
+}


### PR DESCRIPTION
## Pull Request

### Description

This PR implement node fallback with restart-ice request for allowing reconnect to other node.

Re-route Flow:

- If dest-node is same zone with gateway -> return Some(dest) if online
- If dest-node is other zone -> find dest zone gateway and return Some(gateway_node) if available

If no dest found (node or gateway), then select from pool based on client IP

### Related Issue

https://github.com/8xFF/atm0s-media-server/issues/383

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
