### PR TITLE
refactor: config zone id node id media port, get console lists

### DIFF
--- a/bin/connector_z0_n1.sh
+++ b/bin/connector_z0_n1.sh
@@ -1,9 +1,0 @@
-RUST_LOG=info \
-RUST_BACKTRACE=1 \
-cargo run -- \
-    --node-id 4 \
-    --sdn-port 10004 \
-    --sdn-zone 0 \
-    --seeds 1@/ip4/127.0.0.1/udp/10001 \
-    connector \
-    --s3-uri "http://minioadmin:minioadmin@127.0.0.1:9000/record"

--- a/bin/connector_z256_n1.sh
+++ b/bin/connector_z256_n1.sh
@@ -1,9 +1,0 @@
-RUST_LOG=info \
-RUST_BACKTRACE=1 \
-cargo run -- \
-    --http-port 3000 \
-    --node-id 259 \
-    --sdn-port 11003 \
-    --sdn-zone 256 \
-    --seeds 256@/ip4/127.0.0.1/udp/11000 \
-    connector

--- a/bin/src/http/api_console/cluster.rs
+++ b/bin/src/http/api_console/cluster.rs
@@ -1,6 +1,7 @@
-use crate::server::console_storage::{Zone, ZoneDetails};
+use crate::server::console_storage::{ConsoleNode, Zone, ZoneDetails};
 
 use super::{super::Response, ConsoleApisCtx, ConsoleAuthorization};
+use media_server_protocol::cluster::ZoneId;
 use poem::web::Data;
 use poem_openapi::{param::Path, payload::Json, OpenApi};
 
@@ -8,6 +9,16 @@ pub struct Apis;
 
 #[OpenApi]
 impl Apis {
+    /// get consoles from all zones
+    #[oai(path = "/consoles", method = "get")]
+    async fn consoles(&self, _auth: ConsoleAuthorization, Data(ctx): Data<&ConsoleApisCtx>) -> Json<Response<Vec<ConsoleNode>>> {
+        Json(Response {
+            status: true,
+            data: Some(ctx.storage.consoles()),
+            ..Default::default()
+        })
+    }
+
     /// get zones
     #[oai(path = "/zones", method = "get")]
     async fn zones(&self, _auth: ConsoleAuthorization, Data(ctx): Data<&ConsoleApisCtx>) -> Json<Response<Vec<Zone>>> {
@@ -21,7 +32,7 @@ impl Apis {
     /// get zone
     #[oai(path = "/zones/:zone_id", method = "get")]
     async fn zone(&self, _auth: ConsoleAuthorization, zone_id: Path<u32>, Data(ctx): Data<&ConsoleApisCtx>) -> Json<Response<ZoneDetails>> {
-        if let Some(zone) = ctx.storage.zone(zone_id.0) {
+        if let Some(zone) = ctx.storage.zone(ZoneId(zone_id.0)) {
             Json(Response {
                 status: true,
                 data: Some(zone),

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use atm0s_sdn::{NodeAddr, NodeId};
+use media_server_protocol::cluster::ZoneId;
 
 mod errors;
 mod http;
@@ -18,6 +19,6 @@ pub struct NodeConfig {
     pub secret: String,
     pub seeds: Vec<NodeAddr>,
     pub bind_addrs: Vec<SocketAddr>,
-    pub zone: u32,
+    pub zone: ZoneId,
     pub bind_addrs_alt: Vec<SocketAddr>,
 }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -3,6 +3,7 @@ use std::net::{IpAddr, SocketAddr};
 use atm0s_media_server::{server, NodeConfig};
 use atm0s_sdn::NodeAddr;
 use clap::Parser;
+use media_server_protocol::cluster::ZoneId;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 const MAX_ZONE_ID: u32 = 1u32 << 24;
@@ -122,11 +123,11 @@ async fn main() {
             .collect::<Vec<_>>()
     };
     let node = NodeConfig {
-        node_id: (args.sdn_zone_id << 8) | args.sdn_zone_idx as u32,
+        node_id: ZoneId(args.sdn_zone_id).to_node_id(args.sdn_zone_idx),
         secret: args.secret,
         seeds: args.seeds,
         bind_addrs,
-        zone: args.sdn_zone_id << 8,
+        zone: ZoneId(args.sdn_zone_id),
         bind_addrs_alt: args.node_ip_alt.into_iter().map(|ip| SocketAddr::new(ip, sdn_port)).collect::<Vec<_>>(),
     };
 

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -30,7 +30,7 @@ struct Args {
 
     /// The 8-bit index of the current node within the SDN zone.
     #[arg(env, long, default_value_t = 0)]
-    sdn_zone_idx: u8,
+    sdn_zone_node_id: u8,
 
     /// Manually specify the IP address of the node. This disables IP autodetection.
     #[arg(env, long)]
@@ -123,7 +123,7 @@ async fn main() {
             .collect::<Vec<_>>()
     };
     let node = NodeConfig {
-        node_id: ZoneId(args.sdn_zone_id).to_node_id(args.sdn_zone_idx),
+        node_id: ZoneId(args.sdn_zone_id).to_node_id(args.sdn_zone_node_id),
         secret: args.secret,
         seeds: args.seeds,
         bind_addrs,

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1,67 +1,69 @@
 use std::net::{IpAddr, SocketAddr};
 
 use atm0s_media_server::{server, NodeConfig};
-use atm0s_sdn::{NodeAddr, NodeId};
+use atm0s_sdn::NodeAddr;
 use clap::Parser;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+const MAX_ZONE_ID: u32 = 1u32 << 24;
 
 /// Scalable Media Server solution for WebRTC, RTMP, and SIP.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Http port
+    /// HTTP port for incoming requests.
     #[arg(env, long)]
     http_port: Option<u16>,
 
-    /// Run http with tls or not
+    /// Enable TLS for HTTP connections (set to the port number for HTTPS).
     #[arg(env, long)]
     http_tls: Option<u16>,
 
-    /// Sdn port
+    /// SDN (Software-Defined Networking) port.
     #[arg(env, long, default_value_t = 0)]
     sdn_port: u16,
 
-    /// Sdn Zone, which is 32bit number with last 8bit is 0
+    /// SDN zone identifier, a 24-bit number representing the zone ID.
     #[arg(env, long, default_value_t = 0)]
-    sdn_zone: u32,
+    sdn_zone_id: u32,
 
-    /// Current Node ID
-    #[arg(env, long, default_value_t = 1)]
-    node_id: NodeId,
+    /// The 8-bit index of the current node within the SDN zone.
+    #[arg(env, long, default_value_t = 0)]
+    sdn_zone_idx: u8,
 
-    /// Setting the single node IP option will disable the autodetect IP addresses logic
+    /// Manually specify the IP address of the node. This disables IP autodetection.
     #[arg(env, long)]
     node_ip: Option<IpAddr>,
 
-    /// Some alternative node IPs, which are useful with some cloud providers behind NAT, like AWS or GCP ...
+    /// Alternative IP addresses for the node, useful for environments like AWS or GCP that are behind NAT.
     #[arg(env, long)]
     node_ip_alt: Vec<IpAddr>,
 
-    /// Enable private ip
+    /// Enable private IP addresses for the node.
     #[arg(env, long)]
     enable_private_ip: bool,
 
-    /// Enable ipv6
+    /// Enable IPv6 support.
     #[arg(env, long)]
     enable_ipv6: bool,
 
-    /// Cluster Secret Key
+    /// Cluster secret key used for secure communication between nodes.
     #[arg(env, long, default_value = "insecure")]
     secret: String,
 
-    /// Neighbors
+    /// Addresses of neighboring nodes for cluster communication.
     #[arg(env, long)]
     seeds: Vec<NodeAddr>,
 
-    /// Workers
+    /// Number of worker threads to spawn.
     #[arg(env, long, default_value_t = 1)]
     workers: usize,
 
-    /// Enable sentry report
+    /// Disable Sentry error reporting.
     #[arg(env, long)]
     sentry_disable: bool,
 
-    /// Sentry report endpoint
+    /// Sentry error reporting endpoint.
     #[arg(env, long, default_value = "https://46f5e9a11d430eb479b516fc12033e78@o4507218956386304.ingest.us.sentry.io/4507739106836480")]
     sentry_endpoint: String,
 
@@ -80,6 +82,8 @@ async fn main() {
     let args: Args = Args::parse();
     tracing_subscriber::registry().with(fmt::layer()).with(EnvFilter::from_default_env()).init();
 
+    assert!(args.sdn_zone_id < MAX_ZONE_ID, "sdn_zone_id must < {MAX_ZONE_ID}");
+
     if !args.sentry_disable {
         let _guard = sentry::init((
             args.sentry_endpoint.as_str(),
@@ -91,9 +95,18 @@ async fn main() {
     }
 
     let http_port = args.http_port;
+    let sdn_port = if args.sdn_port > 0 {
+        args.sdn_port
+    } else {
+        // We get a free port
+        let udp_socket = std::net::UdpSocket::bind("0.0.0.0:0").expect("Should get free port");
+        udp_socket.local_addr().expect("Should get free port").port()
+    };
+
     let workers = args.workers;
+
     let bind_addrs = if let Some(ip) = args.node_ip {
-        vec![SocketAddr::new(ip, args.sdn_port)]
+        vec![SocketAddr::new(ip, sdn_port)]
     } else {
         local_ip_address::list_afinet_netifas()
             .expect("Should have list interfaces")
@@ -103,18 +116,18 @@ async fn main() {
                     IpAddr::V4(ipv4) => !ipv4.is_private() || args.enable_private_ip,
                     IpAddr::V6(ipv6) => !ipv6.is_unspecified() && !ipv6.is_multicast() && (!ipv6.is_loopback() || args.enable_private_ip) && args.enable_ipv6,
                 };
-                allow && std::net::UdpSocket::bind(SocketAddr::new(*ip, 0)).is_ok()
+                allow && std::net::UdpSocket::bind(SocketAddr::new(*ip, sdn_port)).is_ok()
             })
-            .map(|(_name, ip)| SocketAddr::new(ip, args.sdn_port))
+            .map(|(_name, ip)| SocketAddr::new(ip, sdn_port))
             .collect::<Vec<_>>()
     };
     let node = NodeConfig {
-        node_id: args.node_id,
+        node_id: (args.sdn_zone_id << 8) | args.sdn_zone_idx as u32,
         secret: args.secret,
         seeds: args.seeds,
         bind_addrs,
-        zone: args.sdn_zone,
-        bind_addrs_alt: args.node_ip_alt.into_iter().map(|ip| SocketAddr::new(ip, args.sdn_port)).collect::<Vec<_>>(),
+        zone: args.sdn_zone_id << 8,
+        bind_addrs_alt: args.node_ip_alt.into_iter().map(|ip| SocketAddr::new(ip, sdn_port)).collect::<Vec<_>>(),
     };
 
     log::info!("Bind addrs {:?}, bind addrs alt {:?}", node.bind_addrs, node.bind_addrs_alt);

--- a/bin/src/server/console/storage.rs
+++ b/bin/src/server/console/storage.rs
@@ -212,7 +212,7 @@ impl Storage {
     pub fn consoles(&self) -> Vec<ConsoleNode> {
         self.zones
             .iter()
-            .map(|(id, z)| {
+            .flat_map(|(_id, z)| {
                 z.consoles
                     .iter()
                     .map(|(id, g)| ConsoleNode {
@@ -225,8 +225,7 @@ impl Storage {
                     })
                     .collect::<Vec<_>>()
             })
-            .flatten()
-            .collect::<Vec<_>>()
+            .collect()
     }
 
     pub fn zones(&self) -> Vec<Zone> {

--- a/bin/src/server/gateway.rs
+++ b/bin/src/server/gateway.rs
@@ -49,32 +49,32 @@ type TW = ();
 
 #[derive(Debug, Parser)]
 pub struct Args {
-    /// Location latude
+    /// Location latitude.
     #[arg(env, long, default_value_t = 0.0)]
     lat: f32,
 
-    /// Location longtude
+    /// Location longitude.
     #[arg(env, long, default_value_t = 0.0)]
     lon: f32,
 
-    /// GeoIp database
+    /// Path to the GeoIP database.
     #[arg(env, long, default_value = "./maxminddb-data/GeoLite2-City.mmdb")]
     geo_db: String,
 
-    /// Max cpu usage (in percent) of media-node or gateway-node we allow to route to
+    /// Maximum CPU usage (in percent) allowed for routing to a media node or gateway node.
     #[arg(env, long, default_value_t = 60)]
     max_cpu: u8,
 
-    /// Max memory usage (in percent) of media-node or gateway-node we allow to route to
+    /// Maximum memory usage (in percent) allowed for routing to a media node or gateway node.
     #[arg(env, long, default_value_t = 80)]
     max_memory: u8,
 
-    /// Max disk usage (in percent) of media-node or gateway-node we allow to route to
+    /// Maximum disk usage (in percent) allowed for routing to a media node or gateway node.
     #[arg(env, long, default_value_t = 90)]
     max_disk: u8,
 
-    /// Port for binding rtpengine command UDP socket.
-    #[arg(env, long, default_value = "127.0.0.1:22222")]
+    /// The port for binding the RTPengine command UDP socket.
+    #[arg(env, long)]
     rtpengine_cmd_addr: Option<SocketAddr>,
 }
 

--- a/bin/z0_connector_n4.sh
+++ b/bin/z0_connector_n4.sh
@@ -2,7 +2,7 @@ RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
     --sdn-zone-id 0 \
-    --sdn-zone-idx 4 \
+    --sdn-zone-node-id 4 \
     --seeds 1@/ip4/127.0.0.1/udp/10001 \
     connector \
         --s3-uri "http://minioadmin:minioadmin@127.0.0.1:9000/record"

--- a/bin/z0_connector_n4.sh
+++ b/bin/z0_connector_n4.sh
@@ -1,0 +1,8 @@
+RUST_LOG=info \
+RUST_BACKTRACE=1 \
+cargo run -- \
+    --sdn-zone-id 0 \
+    --sdn-zone-idx 4 \
+    --seeds 1@/ip4/127.0.0.1/udp/10001 \
+    connector \
+        --s3-uri "http://minioadmin:minioadmin@127.0.0.1:9000/record"

--- a/bin/z0_console_n0.sh
+++ b/bin/z0_console_n0.sh
@@ -4,7 +4,7 @@ cargo run -- \
     --http-port 8080 \
     --sdn-port 10000 \
     --sdn-zone-id 0 \
-    --sdn-zone-idx 0 \
+    --sdn-zone-node-id 0 \
     --enable-private-ip \
     --workers 2 \
     console

--- a/bin/z0_console_n0.sh
+++ b/bin/z0_console_n0.sh
@@ -2,9 +2,9 @@ RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
     --http-port 8080 \
-    --node-id 0 \
     --sdn-port 10000 \
-    --sdn-zone 0 \
+    --sdn-zone-id 0 \
+    --sdn-zone-idx 0 \
     --enable-private-ip \
     --workers 2 \
     console

--- a/bin/z0_gate_n1.sh
+++ b/bin/z0_gate_n1.sh
@@ -5,7 +5,7 @@ cargo run -- \
     --enable-private-ip \
     --sdn-port 10001 \
     --sdn-zone-id 0 \
-    --sdn-zone-idx 1 \
+    --sdn-zone-node-id 1 \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
     --workers 2 \
     gateway \

--- a/bin/z0_gate_n1.sh
+++ b/bin/z0_gate_n1.sh
@@ -2,10 +2,10 @@ RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
     --http-port 3000 \
-    --node-id 1 \
     --enable-private-ip \
     --sdn-port 10001 \
-    --sdn-zone 0 \
+    --sdn-zone-id 0 \
+    --sdn-zone-idx 1 \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
     --workers 2 \
     gateway \

--- a/bin/z0_media_n2.sh
+++ b/bin/z0_media_n2.sh
@@ -3,7 +3,7 @@ RUST_BACKTRACE=1 \
 cargo run -- \
     --enable-private-ip \
     --sdn-zone-id 0 \
-    --sdn-zone-idx 2 \
+    --sdn-zone-node-id 2 \
     --seeds 1@/ip4/127.0.0.1/udp/10001 \
     --workers 2 \
     media \

--- a/bin/z0_media_n2.sh
+++ b/bin/z0_media_n2.sh
@@ -1,13 +1,10 @@
 RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
-    --http-port 3002 \
-    --node-id 2 \
     --enable-private-ip \
-    --sdn-port 10002 \
-    --sdn-zone 0 \
+    --sdn-zone-id 0 \
+    --sdn-zone-idx 2 \
     --seeds 1@/ip4/127.0.0.1/udp/10001 \
     --workers 2 \
     media \
-        --webrtc-port-seed 10200 \
         --enable-token-api

--- a/bin/z0_media_n3.sh
+++ b/bin/z0_media_n3.sh
@@ -1,13 +1,10 @@
 RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
-    --http-port 3003 \
-    --node-id 3 \
     --enable-private-ip \
-    --sdn-port 10003 \
-    --sdn-zone 0 \
+    --sdn-zone-id 0 \
+    --sdn-zone-idx 3 \
     --seeds 1@/ip4/127.0.0.1/udp/10001 \
     --workers 2 \
     media \
-        --webrtc-port-seed 10300 \
         --enable-token-api

--- a/bin/z0_media_n3.sh
+++ b/bin/z0_media_n3.sh
@@ -3,7 +3,7 @@ RUST_BACKTRACE=1 \
 cargo run -- \
     --enable-private-ip \
     --sdn-zone-id 0 \
-    --sdn-zone-idx 3 \
+    --sdn-zone-node-id 3 \
     --seeds 1@/ip4/127.0.0.1/udp/10001 \
     --workers 2 \
     media \

--- a/bin/z1_connector_n4.sh
+++ b/bin/z1_connector_n4.sh
@@ -2,7 +2,7 @@ RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
     --sdn-zone-id 1 \
-    --sdn-zone-idx 4 \
+    --sdn-zone-node-id 4 \
     --seeds 256@/ip4/127.0.0.1/udp/11000 \
     connector \
         --s3-uri "http://minioadmin:minioadmin@127.0.0.1:9000/record"

--- a/bin/z1_connector_n4.sh
+++ b/bin/z1_connector_n4.sh
@@ -1,0 +1,8 @@
+RUST_LOG=info \
+RUST_BACKTRACE=1 \
+cargo run -- \
+    --sdn-zone-id 1 \
+    --sdn-zone-idx 4 \
+    --seeds 256@/ip4/127.0.0.1/udp/11000 \
+    connector \
+        --s3-uri "http://minioadmin:minioadmin@127.0.0.1:9000/record"

--- a/bin/z1_gate_n1.sh
+++ b/bin/z1_gate_n1.sh
@@ -4,7 +4,7 @@ cargo run -- \
     --http-port 4000 \
     --enable-private-ip \
     --sdn-zone-id 1 \
-    --sdn-zone-idx 1 \
+    --sdn-zone-node-id 1 \
     --sdn-port 11000 \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
     --workers 2 \

--- a/bin/z1_gate_n1.sh
+++ b/bin/z1_gate_n1.sh
@@ -2,9 +2,9 @@ RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
     --http-port 4000 \
-    --node-id 256 \
     --enable-private-ip \
-    --sdn-zone 256 \
+    --sdn-zone-id 1 \
+    --sdn-zone-idx 1 \
     --sdn-port 11000 \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
     --workers 2 \

--- a/bin/z1_media_n2.sh
+++ b/bin/z1_media_n2.sh
@@ -1,12 +1,10 @@
 RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
-    --http-port 4001 \
-    --node-id 257 \
     --enable-private-ip \
-    --sdn-port 11001 \
-    --sdn-zone 256 \
-    --seeds 256@/ip4/127.0.0.1/udp/11000 \
+    --sdn-zone-id 1 \
+    --sdn-zone-idx 2 \
+    --seeds 257@/ip4/127.0.0.1/udp/11000 \
     --workers 2 \
     media \
         --webrtc-port-seed 11200 \

--- a/bin/z1_media_n2.sh
+++ b/bin/z1_media_n2.sh
@@ -3,7 +3,7 @@ RUST_BACKTRACE=1 \
 cargo run -- \
     --enable-private-ip \
     --sdn-zone-id 1 \
-    --sdn-zone-idx 2 \
+    --sdn-zone-node-id 2 \
     --seeds 257@/ip4/127.0.0.1/udp/11000 \
     --workers 2 \
     media \

--- a/bin/z1_media_n3.sh
+++ b/bin/z1_media_n3.sh
@@ -1,12 +1,10 @@
 RUST_LOG=info \
 RUST_BACKTRACE=1 \
 cargo run -- \
-    --http-port 4002 \
-    --node-id 258 \
     --enable-private-ip \
-    --sdn-port 11002 \
-    --sdn-zone 256 \
-    --seeds 256@/ip4/127.0.0.1/udp/11000 \
+    --sdn-zone-id 1 \
+    --sdn-zone-idx 3 \
+    --seeds 257@/ip4/127.0.0.1/udp/11000 \
     --workers 2 \
     media \
         --webrtc-port-seed 11300 \

--- a/bin/z1_media_n3.sh
+++ b/bin/z1_media_n3.sh
@@ -3,7 +3,7 @@ RUST_BACKTRACE=1 \
 cargo run -- \
     --enable-private-ip \
     --sdn-zone-id 1 \
-    --sdn-zone-idx 3 \
+    --sdn-zone-node-id 3 \
     --seeds 257@/ip4/127.0.0.1/udp/11000 \
     --workers 2 \
     media \

--- a/docs/getting-started/installation/docker-compose.md
+++ b/docs/getting-started/installation/docker-compose.md
@@ -1,5 +1,3 @@
 # Docker-compose (outdate, update needed)
 
-We can use `docker-compose` to deploy atm0s-media-server.
-
-TODO: need to config for both single zone or multi-zones
+We can use [docker-compose](https://github.com/8xFF/atm0s-docker-compose) to deploy atm0s-media-server.

--- a/docs/getting-started/installation/multi-zones.md
+++ b/docs/getting-started/installation/multi-zones.md
@@ -12,9 +12,9 @@ Note that you can deploy multi connectors in some zones to handle room and peer 
 
 ## Prerequisites
 
-- Choose a different zone id for each zone, it is 32bit with format: 0x00_00_XX_00, example: 0, 256, 512
+- Choose a different zone id for each zone, it is 24bit unsigned number.
 - Select a secret for all zones.
 
 ## Deploying each zone, same as a single-zone cluster
 
-The deployment steps are the same as for a single-zone cluster with addition `--zone-id ZONE_ID` param. However, starting from second zone, you don't need to add console node, instead of that you can reuse single console node for all zones.
+The deployment steps are the same as for a single-zone cluster with addition `--sdn-zone-id ZONE_ID` param. However, starting from second zone, you don't need to add console node, instead of that you can reuse single console node for all zones.

--- a/docs/getting-started/installation/single-zone.md
+++ b/docs/getting-started/installation/single-zone.md
@@ -42,7 +42,7 @@ Console node will expose at least 1 tcp port and 1 udp port
 docker run -d --name main-console --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
     --sdn-port 10000 \
-    --sdn-zone-idx 0 \
+    --sdn-zone-node-id 0 \
     --http-port 8080 \
     --enable-private-ip \
     console
@@ -62,7 +62,7 @@ Gateway node will expose at least 1 tcp port and 1 udp port
 docker run -d --name gateway1 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
     --sdn-port 10010 \
-    --sdn-zone-idx 10 \
+    --sdn-zone-node-id 10 \
     --http-port 3000 \
     --enable-private-ip \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
@@ -73,7 +73,7 @@ docker run -d --name gateway1 --net=host ghcr.io/8xff/atm0s-media-gateway:master
 docker run -d --name gateway2 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
     --sdn-port 10011 \
-    --sdn-zone-idx 11 \
+    --sdn-zone-node-id 11 \
     --http-port 3001 \
     --enable-private-ip \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
@@ -93,7 +93,7 @@ In default it will store data inside a sqlite file. For connecting to other data
 docker run -d --name main-connector --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
     --sdn-port 10020 \
-    --sdn-zone-idx 20 \
+    --sdn-zone-node-id 20 \
     --enable-private-ip \
     --seeds 10@/ip4/127.0.0.1/udp/10010 \
     --seeds 11@/ip4/127.0.0.1/udp/10011 \
@@ -107,7 +107,7 @@ docker run -d --name main-connector --net=host ghcr.io/8xff/atm0s-media-gateway:
 docker run -d --name media1 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
     --sdn-port 10100 \
-    --sdn-zone-idx 100 \
+    --sdn-zone-node-id 100 \
     --enable-private-ip \
     --seeds 10@/ip4/127.0.0.1/udp/10010 \
     --seeds 11@/ip4/127.0.0.1/udp/10011 \
@@ -119,7 +119,7 @@ docker run -d --name media1 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
 docker run -d --name media2 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
     --sdn-port 10101 \
-    --sdn-zone-idx 101 \
+    --sdn-zone-node-id 101 \
     --enable-private-ip \
     --seeds 10@/ip4/127.0.0.1/udp/10010 \
     --seeds 11@/ip4/127.0.0.1/udp/10011 \

--- a/docs/getting-started/installation/single-zone.md
+++ b/docs/getting-started/installation/single-zone.md
@@ -41,9 +41,8 @@ Console node will expose at least 1 tcp port and 1 udp port
 ```
 docker run -d --name main-console --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
-    --node-id 0 \
     --sdn-port 10000 \
-    --sdn-zone 0 \
+    --sdn-zone-idx 0 \
     --http-port 8080 \
     --enable-private-ip \
     console
@@ -62,9 +61,8 @@ Gateway node will expose at least 1 tcp port and 1 udp port
 ```
 docker run -d --name gateway1 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
-    --node-id 10 \
     --sdn-port 10010 \
-    --sdn-zone 0 \
+    --sdn-zone-idx 10 \
     --http-port 3000 \
     --enable-private-ip \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
@@ -74,9 +72,8 @@ docker run -d --name gateway1 --net=host ghcr.io/8xff/atm0s-media-gateway:master
 ```
 docker run -d --name gateway2 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
-    --node-id 11 \
     --sdn-port 10011 \
-    --sdn-zone 0 \
+    --sdn-zone-idx 11 \
     --http-port 3001 \
     --enable-private-ip \
     --seeds 0@/ip4/127.0.0.1/udp/10000 \
@@ -95,9 +92,8 @@ In default it will store data inside a sqlite file. For connecting to other data
 ```bash
 docker run -d --name main-connector --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
-    --node-id 20 \
     --sdn-port 10020 \
-    --sdn-zone 0 \
+    --sdn-zone-idx 20 \
     --enable-private-ip \
     --seeds 10@/ip4/127.0.0.1/udp/10010 \
     --seeds 11@/ip4/127.0.0.1/udp/10011 \
@@ -110,9 +106,8 @@ docker run -d --name main-connector --net=host ghcr.io/8xff/atm0s-media-gateway:
 ```bash
 docker run -d --name media1 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
-    --node-id 100 \
     --sdn-port 10100 \
-    --sdn-zone 0 \
+    --sdn-zone-idx 100 \
     --enable-private-ip \
     --seeds 10@/ip4/127.0.0.1/udp/10010 \
     --seeds 11@/ip4/127.0.0.1/udp/10011 \
@@ -123,9 +118,8 @@ docker run -d --name media1 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
 ```bash
 docker run -d --name media2 --net=host ghcr.io/8xff/atm0s-media-gateway:master \
     --secret secr3t \
-    --node-id 101 \
     --sdn-port 10101 \
-    --sdn-zone 0 \
+    --sdn-zone-idx 101 \
     --enable-private-ip \
     --seeds 10@/ip4/127.0.0.1/udp/10010 \
     --seeds 11@/ip4/127.0.0.1/udp/10011 \

--- a/packages/media_gateway/src/store_service.rs
+++ b/packages/media_gateway/src/store_service.rs
@@ -8,9 +8,12 @@ use atm0s_sdn::{
     features::{data, FeaturesControl, FeaturesEvent},
     NodeId, RouteRule, ServiceBroadcastLevel,
 };
-use media_server_protocol::protobuf::{
-    self,
-    cluster_gateway::{gateway_event, ping_event::gateway_origin::Location},
+use media_server_protocol::{
+    cluster::ZoneId,
+    protobuf::{
+        self,
+        cluster_gateway::{gateway_event, ping_event::gateway_origin::Location},
+    },
 };
 use prost::Message as _;
 
@@ -46,7 +49,7 @@ where
     SC: From<Control> + TryInto<Control>,
     SE: From<Event> + TryInto<Event>,
 {
-    pub fn new(zone: u32, lat: f32, lon: f32, max_cpu: u8, max_memory: u8, max_disk: u8) -> Self {
+    pub fn new(zone: ZoneId, lat: f32, lon: f32, max_cpu: u8, max_memory: u8, max_disk: u8) -> Self {
         Self {
             store: GatewayStore::new(zone, Location { lat, lon }, max_cpu, max_memory, max_disk),
             queue: VecDeque::from([ServiceOutput::FeatureControl(data::Control::DataListen(DATA_PORT).into())]),
@@ -192,7 +195,7 @@ impl<UserData, SC, SE, TC, TW> ServiceWorker<UserData, FeaturesControl, Features
 
 pub struct GatewayStoreServiceBuilder<UserData, SC, SE, TC, TW> {
     _tmp: std::marker::PhantomData<(UserData, SC, SE, TC, TW)>,
-    zone: u32,
+    zone: ZoneId,
     lat: f32,
     lon: f32,
     max_memory: u8,
@@ -201,7 +204,7 @@ pub struct GatewayStoreServiceBuilder<UserData, SC, SE, TC, TW> {
 }
 
 impl<UserData, SC, SE, TC, TW> GatewayStoreServiceBuilder<UserData, SC, SE, TC, TW> {
-    pub fn new(zone: u32, lat: f32, lon: f32, max_cpu: u8, max_memory: u8, max_disk: u8) -> Self {
+    pub fn new(zone: ZoneId, lat: f32, lon: f32, max_cpu: u8, max_memory: u8, max_disk: u8) -> Self {
         Self {
             zone,
             lat,

--- a/packages/media_runner/src/worker.rs
+++ b/packages/media_runner/src/worker.rs
@@ -16,7 +16,7 @@ use media_server_connector::agent_service::ConnectorAgentServiceBuilder;
 use media_server_core::cluster::{self, MediaCluster};
 use media_server_gateway::{agent_service::GatewayAgentServiceBuilder, NodeMetrics, ServiceKind, AGENT_SERVICE_ID};
 use media_server_protocol::{
-    cluster::{ClusterMediaInfo, ClusterNodeGenericInfo, ClusterNodeInfo},
+    cluster::{ClusterMediaInfo, ClusterNodeGenericInfo, ClusterNodeInfo, ZoneId},
     gateway::generate_gateway_zone_tag,
     protobuf::{
         cluster_connector::{connector_request, PeerEvent},
@@ -144,7 +144,7 @@ impl<ES: 'static + MediaEdgeSecure> MediaServerWorker<ES> {
         controller: bool,
         sdn_bind_addrs: Vec<SocketAddr>,
         sdn_custom_addrs: Vec<SocketAddr>,
-        sdn_zone: u32,
+        sdn_zone: ZoneId,
         media: MediaConfig<ES>,
     ) -> Self {
         let secure = media.secure.clone(); //TODO why need this?

--- a/packages/media_utils/src/lib.rs
+++ b/packages/media_utils/src/lib.rs
@@ -1,5 +1,4 @@
 mod f16;
-mod sdn;
 mod select;
 mod seq_extend;
 mod seq_rewrite;
@@ -9,7 +8,6 @@ mod ts_rewrite;
 mod uri;
 
 pub use f16::{F16i, F16u};
-pub use sdn::*;
 pub use select::*;
 pub use seq_extend::RtpSeqExtend;
 pub use seq_rewrite::SeqRewrite;

--- a/packages/media_utils/src/sdn.rs
+++ b/packages/media_utils/src/sdn.rs
@@ -1,3 +1,0 @@
-pub fn node_zone_id(node: u32) -> u32 {
-    node & 0xFFFFFF00
-}

--- a/packages/protocol/src/cluster.rs
+++ b/packages/protocol/src/cluster.rs
@@ -1,5 +1,18 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ZoneId(pub u32);
+
+impl ZoneId {
+    pub fn from_node_id(node: u32) -> Self {
+        Self(node >> 8)
+    }
+
+    pub fn to_node_id(&self, idx: u8) -> u32 {
+        self.0 << 8 | idx as u32
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClusterNodeGenericInfo {
     pub addr: String,

--- a/packages/protocol/src/gateway.rs
+++ b/packages/protocol/src/gateway.rs
@@ -1,5 +1,7 @@
-pub fn generate_gateway_zone_tag(zone: u32) -> String {
-    format!("gateway-zone-{}", zone)
+use crate::cluster::ZoneId;
+
+pub fn generate_gateway_zone_tag(zone: ZoneId) -> String {
+    format!("gateway-zone-{}", zone.0)
 }
 
 pub const GATEWAY_RPC_PORT: u16 = 10000;

--- a/packages/rtpengine_ngcontrol/src/transport/udp.rs
+++ b/packages/rtpengine_ngcontrol/src/transport/udp.rs
@@ -11,7 +11,7 @@ pub struct NgUdpTransport {
 
 impl NgUdpTransport {
     pub async fn new(addr: SocketAddr) -> Self {
-        let socket = UdpSocket::bind(addr).await.expect("Should listen on port {port}");
+        let socket = UdpSocket::bind(addr).await.expect("Should listen on {port}");
         log::info!("[NgUdpTransport] listen on addr {addr}");
         Self { socket }
     }


### PR DESCRIPTION
## Pull Request

### Description

This PR updates the SDN configuration. Changed form u32 sdn-zone, node-id to 

- u24 sdn-zone-id: what every you chose for zone_id (but should be smallest as possible for routing efficiency) 
- u8 sdn-zone-node-id: from 0 to 255, which mean you have maximum 256 node in a single zones

### Related Issue

https://github.com/8xFF/atm0s-media-server/issues/409

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
