### PR TITLE
Feature: External authentication/authorization check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rcgen",
+ "reqwest",
  "rtpengine-ngcontrol",
  "rust-embed",
  "rustls 0.23.12",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -38,6 +38,7 @@ sysinfo = { version = "0.30", optional = true }
 hex = { version = "0.4", optional = true }
 mime_guess = { version = "2.0", optional = true }
 sentry = "0.34"
+reqwest = { version = "0.12" }
 
 [features]
 default = ["console", "gateway", "media", "connector", "cert_utils"]

--- a/bin/src/server/gateway.rs
+++ b/bin/src/server/gateway.rs
@@ -76,6 +76,11 @@ pub struct Args {
     /// The port for binding the RTPengine command UDP socket.
     #[arg(env, long)]
     rtpengine_cmd_addr: Option<SocketAddr>,
+
+    /// External HTTP endpoint URI for third-party authentication and authorization.
+    /// The URI should be in the format of `http(s)://<host>:<port>` or `http(s)://example.com`, without the backslash at the end.
+    #[arg(env, long)]
+    ext_auth_uri: Option<String>,
 }
 
 pub async fn run_media_gateway(workers: usize, http_port: Option<u16>, node: NodeConfig, args: Args) {
@@ -96,7 +101,7 @@ pub async fn run_media_gateway(workers: usize, http_port: Option<u16>, node: Nod
         let req_tx = req_tx.clone();
         let secure2 = edge_secure.clone();
         tokio::spawn(async move {
-            if let Err(e) = run_gateway_http_server(http_port, req_tx, secure2, gateway_secure).await {
+            if let Err(e) = run_gateway_http_server(http_port, req_tx, secure2, gateway_secure, args.ext_auth_uri).await {
                 log::error!("HTTP Error: {}", e);
             }
         });

--- a/bin/src/server/media.rs
+++ b/bin/src/server/media.rs
@@ -79,6 +79,11 @@ pub struct Args {
     /// Number of workers for uploading recordings.
     #[arg(env, long, default_value_t = 5)]
     record_upload_worker: usize,
+
+    /// External HTTP endpoint URI for third-party authentication and authorization.
+    /// The URI should be in the format of `http(s)://<host>:<port>` or `http(s)://example.com`, without the backslash at the end.
+    #[arg(env, long)]
+    ext_auth_uri: Option<String>,
 }
 
 pub async fn run_media_server(workers: usize, http_port: Option<u16>, node: NodeConfig, args: Args) {
@@ -96,7 +101,7 @@ pub async fn run_media_server(workers: usize, http_port: Option<u16>, node: Node
         let req_tx = req_tx.clone();
         let secure = secure.clone();
         tokio::spawn(async move {
-            if let Err(e) = run_media_http_server(http_port, req_tx, secure, secure2).await {
+            if let Err(e) = run_media_http_server(http_port, req_tx, secure, secure2, args.ext_auth_uri).await {
                 log::error!("HTTP Error: {}", e);
             }
         });


### PR DESCRIPTION
## Pull Request

### Description
To keep the server functionalities as simple and compact as possible, currently only JWT verification is used to allow users access to a room. But due to the requirements of modern video conferencing applications, further authentication functionalities are needed (Room participant controls like kicking, banning, ...). 
This PR is designed to keep the authen/author out of scope of the server core functions. Developer can now extends the authentication functions by providing a sort of "guard" API HTTP base endpoint.
These "guard" are placed in-front of the authenticated SDK APIs: 
- `/whip/create`
- `/whep/create`
- `/webrtc/connect`
- `/webrtc/ice-restart`
The guard API endpoint should contain all of these APIs when `--ext-auth-uri` is provided for the server. The guard only check for success status from this API for the guard to be passed, if the API failed in any other way, the guard will return UNAUTHORIZED.

## Changes
- New argument for media/gateway server: `--ext-auth-uri Option<String>`. For example: `http://example.com` (without the backslash at the end of the string)

### Related Issue

#378 

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
