### PR TITLE
fix: obs failed to publish video

### DIFF
--- a/packages/transport_webrtc/src/media/h264.rs
+++ b/packages/transport_webrtc/src/media/h264.rs
@@ -5,7 +5,6 @@ const H264_NALU_TTYPE_SPS: u32 = 7;
 const H264_NALU_TYPE_BITMASK: u32 = 0x1F;
 
 pub fn parse_rtp(payload: &[u8], profile: H264Profile, rid: Option<u8>) -> Option<MediaMeta> {
-    let rid = rid?;
     if payload.len() < 4 {
         None
     } else {
@@ -16,7 +15,7 @@ pub fn parse_rtp(payload: &[u8], profile: H264Profile, rid: Option<u8>) -> Optio
         Some(MediaMeta::H264 {
             key,
             profile,
-            sim: Some(H264Sim { spatial: rid }),
+            sim: rid.map(|rid| H264Sim { spatial: rid }),
         })
     }
 }


### PR DESCRIPTION
### Description

This PR fixed missing for handling non-simulcast h264 video packet.

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
