### PR TITLE
feat: now we have 2 mode: multi-tenancy with dynamic app sync or static secret

### DIFF
--- a/bin/src/server/media.rs
+++ b/bin/src/server/media.rs
@@ -93,8 +93,12 @@ pub async fn run_media_server(workers: usize, http_port: Option<u16>, node: Node
     let secure = Arc::new(MediaEdgeSecureJwt::from(node.secret.as_bytes()));
     let (req_tx, mut req_rx) = tokio::sync::mpsc::channel(1024);
     if let Some(http_port) = http_port {
-        let app_storage = Arc::new(MultiTenancyStorage::new(&node.secret, None));
-        let secure2 = args.enable_token_api.then(|| Arc::new(MediaGatewaySecureJwt::new(node.secret.as_bytes(), app_storage)));
+        let secure2: Option<Arc<MediaGatewaySecureJwt>> = args.enable_token_api.then(|| {
+            // we only have one app for token api
+            // this mode is used for testing purpose
+            let app_storage = Arc::new(MultiTenancyStorage::new_with_single(&node.secret, None));
+            Arc::new(MediaGatewaySecureJwt::new(node.secret.as_bytes(), app_storage))
+        });
         let req_tx = req_tx.clone();
         let secure = secure.clone();
         tokio::spawn(async move {

--- a/docs/user-guide/integration.md
+++ b/docs/user-guide/integration.md
@@ -17,22 +17,25 @@ We support integration with other systems through the following methods:
 
 The media server employs an efficient and secure approach for token generation and validation. It does not store any token information in its database and does not rely on external services for token validation. Instead, each node in the cluster validates tokens based on its configuration.
 
-Currently, the media server uses JWT with a static cluster secret for token generation. It also supports multi-tenancy applications by synchronizing data from an external HTTP source that responds with a JSON structure like:
+Currently, the media server uses JWT with a static cluster secret for token generation. It also supports multi-tenancy mode by synchronizing data from an external HTTP source that responds with a JSON structure like:
 
 ```json
 {
-  "apps": {
-    "app1": {
-      "secret": "secret1"
+  "apps": [
+    {
+      "app_id": "app1",
+      "app_secret": "secret1",
+      "hook": "http://hook_endpoint?params=what_ever_ouwant"
     },
-    "app2": {
-      "secret": "secret2"
+    {
+      "app_id": "app2",
+      "app_secret": "secret2"
     }
-  }
+  ]
 }
 ```
 
-The synchronization endpoint can be used with the `--multi-tenancy-sync` option of the gateway node. Instead of using the root secret, we can use the app secret to create tokens specific to that app.
+The synchronization endpoint can be used with the --multi-tenancy-sync option of the gateway node. There are two separate modes: multi-tenancy and fixed secret. In multi-tenancy mode, you use the app secret to create tokens specific to each app. Once --multi-tenancy-sync is set, the default secret becomes unusable, and you can only use secrets from the list of apps provided in the --multi-tenancy-sync response. In fixed secret mode, the root secret is used for token creation.
 
 We can use token generation APIs to create tokens. For more information, please refer to the HTTP APIs section below.
 


### PR DESCRIPTION
### Description

This PR updates the multi tenancy feature configuration. Now we have 2 separated mode:

- Single app only with static secret
- Dynamic (multi-tenancy) apps if app sync url is provided with gateway and connector.

### Related Issue

No

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
