### PR TITLE
fix: handle video orientation from webrtc-extension

### DIFF
--- a/packages/media_core/src/endpoint/internal/local_track/packet_selector.rs
+++ b/packages/media_core/src/endpoint/internal/local_track/packet_selector.rs
@@ -272,7 +272,7 @@ mod tests {
             marker: true,
             nackable: false,
             layers: None,
-            meta: MediaMeta::Vp8 { key, sim: None },
+            meta: MediaMeta::Vp8 { key, sim: None, rotation: None },
             data: vec![1, 2, 3],
         }
     }

--- a/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_h264_sim.rs
+++ b/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_h264_sim.rs
@@ -50,7 +50,13 @@ impl Selector {
         if self.target == self.current {
             return;
         }
-        if let MediaMeta::H264 { key, profile: _, sim: Some(_sim) } = &mut pkt.meta {
+        if let MediaMeta::H264 {
+            key,
+            profile: _,
+            sim: Some(_sim),
+            rotation: _,
+        } = &mut pkt.meta
+        {
             match (self.current, self.target) {
                 (Some(current), Some(target)) => {
                     match target.cmp(&current) {
@@ -106,7 +112,12 @@ impl Selector {
     fn is_allow(&mut self, _ctx: &mut VideoSelectorCtx, pkt: &mut MediaPacket) -> Option<()> {
         let current = self.current?;
         match &mut pkt.meta {
-            MediaMeta::H264 { key: _, profile: _, sim: Some(sim) } => {
+            MediaMeta::H264 {
+                key: _,
+                profile: _,
+                sim: Some(sim),
+                rotation: _,
+            } => {
                 if current == sim.spatial {
                     Some(())
                 } else {
@@ -177,6 +188,7 @@ mod tests {
                 key,
                 profile: H264Profile::P42001fNonInterleaved,
                 sim: Some(H264Sim { spatial }),
+                rotation: None,
             },
             data: vec![1, 2, 3],
         }

--- a/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp8_sim.rs
+++ b/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp8_sim.rs
@@ -70,7 +70,7 @@ impl Selector {
         if self.target == self.current {
             return;
         }
-        if let MediaMeta::Vp8 { key, sim: Some(sim) } = &mut pkt.meta {
+        if let MediaMeta::Vp8 { key, sim: Some(sim), rotation: _ } = &mut pkt.meta {
             match (&mut self.current, &self.target) {
                 (Some(current), Some(target)) => {
                     match target.spatial.cmp(&current.spatial) {
@@ -164,7 +164,7 @@ impl Selector {
     fn is_allow(&mut self, ctx: &mut VideoSelectorCtx, pkt: &mut MediaPacket) -> Option<()> {
         let current = self.current.as_ref()?;
         match &mut pkt.meta {
-            MediaMeta::Vp8 { key: _, sim: Some(sim) } => {
+            MediaMeta::Vp8 { key: _, sim: Some(sim), rotation: _ } => {
                 if sim.spatial == current.spatial && sim.temporal <= current.temporal {
                     log::trace!(
                         "[Vp8SimSelector] allow {} {}, seq {}, ts {}, tl0idx {:?} pic_id {:?}",
@@ -271,6 +271,7 @@ mod tests {
                     temporal,
                     layer_sync,
                 }),
+                rotation: None,
             },
             data: vec![1, 2, 3],
         }
@@ -301,6 +302,7 @@ mod tests {
                             MediaMeta::Vp8 {
                                 key: _,
                                 sim: Some(Vp8Sim { picture_id, tl0_pic_idx, .. }),
+                                rotation: _,
                             } => (picture_id.unwrap(), tl0_pic_idx.unwrap()),
                             _ => panic!("Should not happen"),
                         };

--- a/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp9_svc.rs
+++ b/packages/media_core/src/endpoint/internal/local_track/packet_selector/video_vp9_svc.rs
@@ -83,7 +83,13 @@ impl Selector {
         if self.target == self.current {
             return;
         }
-        if let MediaMeta::Vp9 { key, profile: _, svc: Some(svc) } = &mut pkt.meta {
+        if let MediaMeta::Vp9 {
+            key,
+            profile: _,
+            svc: Some(svc),
+            rotation: _,
+        } = &mut pkt.meta
+        {
             match (&mut self.current, &self.target) {
                 (Some(current), Some(target)) => {
                     match target.spatial.cmp(&current.spatial) {
@@ -181,7 +187,12 @@ impl Selector {
     fn is_allow(&mut self, ctx: &mut VideoSelectorCtx, pkt: &mut MediaPacket) -> Option<()> {
         let current = self.current.as_ref()?;
         match &mut pkt.meta {
-            MediaMeta::Vp9 { key: _, profile: _, svc: Some(svc) } => {
+            MediaMeta::Vp9 {
+                key: _,
+                profile: _,
+                svc: Some(svc),
+                rotation: _,
+            } => {
                 if svc.spatial <= current.spatial && svc.temporal <= current.temporal {
                     log::trace!(
                         "[Vp9SvcSelector] allow {} {}, seq {}, ts {}, marker {}, pic_id {:?}",
@@ -289,6 +300,7 @@ mod tests {
                     spatial_layers: None,
                     predicted_frame: false,
                 }),
+                rotation: None,
             },
             data: vec![1, 2, 3],
         }

--- a/packages/media_record/src/convert/codec/vpx_demuxer.rs
+++ b/packages/media_record/src/convert/codec/vpx_demuxer.rs
@@ -26,12 +26,15 @@ impl VpxDemuxer {
         let (mut depacketizer, is_key_frame) = match rtp.meta {
             media_server_protocol::media::MediaMeta::Opus { .. } => panic!("wrong codec"),
             media_server_protocol::media::MediaMeta::H264 { .. } => panic!("wrong codec"),
-            media_server_protocol::media::MediaMeta::Vp8 { key, sim } => {
+            media_server_protocol::media::MediaMeta::Vp8 { key, sim, rotation } => {
                 if let Some(sim) = sim {
                     if sim.spatial != 0 {
                         //TODO: how to get maximum quality
                         return None;
                     }
+                }
+                if let Some(_rotation) = rotation {
+                    //TODO: process rotation
                 }
                 (Box::new(rtp::codecs::vp8::Vp8Packet::default()) as Box<dyn Depacketizer>, key)
             }

--- a/packages/protocol/proto/record/file_rec.proto
+++ b/packages/protocol/proto/record/file_rec.proto
@@ -31,11 +31,26 @@ message RecordChunk {
     }
 
     message TrackMedia {
+        enum Orientation {
+            UNKNOWN = 0;
+            DEG0 = 1;
+            DEG90 = 2;
+            DEG180 = 3;
+            DEG270 = 4;
+        }
+
+        message AudioLevel {
+            bool present = 1;
+            int32 level = 2;
+        }
+
         uint32 media_ts = 1;
         uint32 media_seq = 2;
         bool marker = 3;
         uint32 codec = 4;
         bytes payload = 5;
+        Orientation orientation = 6;
+        AudioLevel audio_level = 7;
     }
 
     uint32 track_id = 1;

--- a/packages/protocol/src/media.rs
+++ b/packages/protocol/src/media.rs
@@ -197,6 +197,14 @@ pub enum MediaScaling {
     Simulcast,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MediaOrientation {
+    Deg0,
+    Deg90,
+    Deg180,
+    Deg270,
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum MediaCodec {
     Opus,
@@ -207,10 +215,26 @@ pub enum MediaCodec {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MediaMeta {
-    Opus { audio_level: Option<i8> },
-    H264 { key: bool, profile: H264Profile, sim: Option<H264Sim> },
-    Vp8 { key: bool, sim: Option<Vp8Sim> },
-    Vp9 { key: bool, profile: Vp9Profile, svc: Option<Vp9Svc> },
+    Opus {
+        audio_level: Option<i8>,
+    },
+    H264 {
+        key: bool,
+        profile: H264Profile,
+        sim: Option<H264Sim>,
+        rotation: Option<MediaOrientation>,
+    },
+    Vp8 {
+        key: bool,
+        sim: Option<Vp8Sim>,
+        rotation: Option<MediaOrientation>,
+    },
+    Vp9 {
+        key: bool,
+        profile: Vp9Profile,
+        svc: Option<Vp9Svc>,
+        rotation: Option<MediaOrientation>,
+    },
 }
 
 impl MediaMeta {
@@ -235,6 +259,20 @@ impl MediaMeta {
             Self::H264 { profile, .. } => MediaCodec::H264(*profile),
             Self::Vp8 { .. } => MediaCodec::Vp8,
             Self::Vp9 { profile, .. } => MediaCodec::Vp9(*profile),
+        }
+    }
+
+    pub fn rotation(&self) -> Option<MediaOrientation> {
+        match self {
+            Self::H264 { rotation, .. } | Self::Vp8 { rotation, .. } | Self::Vp9 { rotation, .. } => *rotation,
+            Self::Opus { .. } => None,
+        }
+    }
+
+    pub fn audio_level(&self) -> Option<i8> {
+        match self {
+            Self::Opus { audio_level, .. } => *audio_level,
+            _ => None,
         }
     }
 }

--- a/packages/transport_webrtc/src/media/h264.rs
+++ b/packages/transport_webrtc/src/media/h264.rs
@@ -1,10 +1,10 @@
-use media_server_protocol::media::{H264Profile, H264Sim, MediaMeta};
+use media_server_protocol::media::{H264Profile, H264Sim, MediaMeta, MediaOrientation};
 
 const H264_NALU_TTYPE_STAP_A: u32 = 24;
 const H264_NALU_TTYPE_SPS: u32 = 7;
 const H264_NALU_TYPE_BITMASK: u32 = 0x1F;
 
-pub fn parse_rtp(payload: &[u8], profile: H264Profile, rid: Option<u8>) -> Option<MediaMeta> {
+pub fn parse_rtp(payload: &[u8], profile: H264Profile, rid: Option<u8>, rotation: Option<MediaOrientation>) -> Option<MediaMeta> {
     if payload.len() < 4 {
         None
     } else {
@@ -16,6 +16,7 @@ pub fn parse_rtp(payload: &[u8], profile: H264Profile, rid: Option<u8>) -> Optio
             key,
             profile,
             sim: rid.map(|rid| H264Sim { spatial: rid }),
+            rotation,
         })
     }
 }

--- a/packages/transport_webrtc/src/media/vp8.rs
+++ b/packages/transport_webrtc/src/media/vp8.rs
@@ -1,7 +1,7 @@
 use super::bit_read::BitRead;
-use media_server_protocol::media::{MediaMeta, Vp8Sim};
+use media_server_protocol::media::{MediaMeta, MediaOrientation, Vp8Sim};
 
-pub fn parse_rtp(packet: &[u8], rid: Option<u8>) -> Option<MediaMeta> {
+pub fn parse_rtp(packet: &[u8], rid: Option<u8>, rotation: Option<MediaOrientation>) -> Option<MediaMeta> {
     let payload_len = packet.len();
     if payload_len < 4 {
         return None;
@@ -93,9 +93,10 @@ pub fn parse_rtp(packet: &[u8], rid: Option<u8>) -> Option<MediaMeta> {
                 },
                 layer_sync: vp8.y != 0,
             }),
+            rotation,
         })
     } else {
-        Some(MediaMeta::Vp8 { key: is_key, sim: None })
+        Some(MediaMeta::Vp8 { key: is_key, sim: None, rotation })
     }
 }
 

--- a/packages/transport_webrtc/src/media/vp9.rs
+++ b/packages/transport_webrtc/src/media/vp9.rs
@@ -1,14 +1,14 @@
-use media_server_protocol::media::{MediaMeta, Vp9Profile, Vp9Svc};
+use media_server_protocol::media::{MediaMeta, MediaOrientation, Vp9Profile, Vp9Svc};
 
 use super::bit_read::BitRead;
 
 const MAX_SPATIAL_LAYERS: u8 = 5;
 const MAX_VP9REF_PICS: usize = 3;
 
-pub fn parse_rtp(payload: &[u8], profile: Vp9Profile) -> Option<MediaMeta> {
+pub fn parse_rtp(payload: &[u8], profile: Vp9Profile, rotation: Option<MediaOrientation>) -> Option<MediaMeta> {
     let mut header = Vp9Header::default();
     let (key, svc) = header.parse_from(payload).ok()?;
-    Some(MediaMeta::Vp9 { key, profile, svc })
+    Some(MediaMeta::Vp9 { key, profile, svc, rotation })
 }
 
 #[allow(unused_assignments)]

--- a/packages/transport_webrtc/src/transport.rs
+++ b/packages/transport_webrtc/src/transport.rs
@@ -32,11 +32,13 @@ use str0m::{
     ice::IceCreds,
     media::{KeyframeRequestKind, Mid},
     net::{Protocol, Receive},
-    rtp::ExtensionValues,
     Candidate, Rtc,
 };
 
-use crate::{media::LocalMediaConvert, WebrtcError};
+use crate::{
+    media::{to_webrtc_extensions, LocalMediaConvert},
+    WebrtcError,
+};
 
 mod bwe_state;
 mod webrtc;
@@ -239,7 +241,8 @@ impl<ES: 'static + MediaEdgeSecure> TransportWebrtc<ES> {
                 let mut api = self.rtc.direct_api();
                 let tx = return_if_none!(api.stream_tx_by_mid(mid, None));
 
-                if let Err(e) = tx.write_rtp(pt, seq2.into(), pkt.ts, now, pkt.marker, ExtensionValues::default(), pkt.nackable, pkt.data) {
+                let ext = to_webrtc_extensions(&pkt);
+                if let Err(e) = tx.write_rtp(pt, seq2.into(), pkt.ts, now, pkt.marker, ext, pkt.nackable, pkt.data) {
                     log::error!("[TransportWebrtc] write rtp error {e}");
                 }
             }


### PR DESCRIPTION
### Description

This PR add logic for supporting video orientation extension from WebRTC

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.