### PR TITLE
fix: webrtc transport stuck on connect_error cause memory leak

### DIFF
--- a/packages/media_core/src/endpoint.rs
+++ b/packages/media_core/src/endpoint.rs
@@ -291,6 +291,7 @@ where
     type Time = Instant;
 
     fn is_empty(&self) -> bool {
+        // we don't need to check shutdown here, because it can be shutdown by transport itself
         self.internal.is_empty() && self.transport.is_empty()
     }
 


### PR DESCRIPTION
### Description

This PR fix webrtc transport close stuck on connect_error, this cause memory leak bug

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
