### PR TITLE
fix: some time connector handle duplicate incorrect, ensure it success

### DIFF
--- a/bin/src/server/connector.rs
+++ b/bin/src/server/connector.rs
@@ -177,7 +177,7 @@ pub async fn run_media_connector(workers: usize, http_port: Option<u16>, node: N
                     connector_storage.on_tick().await;
                 }
                 select2::OrOutput::Right(Some((from, ts, req_id, event))) => {
-                    match connector_storage.on_event(from, ts, event).await {
+                    match connector_storage.on_event(from, ts, req_id, event).await {
                         Some(res) => {
                             if let Err(e) = connector_handler_control_tx.send(handler_service::Control::Res(from, req_id, res)).await {
                                 log::error!("[Connector] send control to service error {:?}", e);

--- a/packages/media_connector/src/handler_service.rs
+++ b/packages/media_connector/src/handler_service.rs
@@ -24,8 +24,6 @@ pub enum Event {
     Req(NodeId, u64, u64, connector_request::Request),
 }
 
-type ReqUuid = (NodeId, u64, u64);
-
 pub struct ConnectorHandlerService<UserData, SC, SE, TC, TW> {
     subscriber: Option<ServiceControlActor<UserData>>,
     queue: VecDeque<ServiceOutput<UserData, FeaturesControl, SE, TW>>,

--- a/packages/media_connector/src/lib.rs
+++ b/packages/media_connector/src/lib.rs
@@ -99,7 +99,7 @@ pub trait Storage {
     type Q: Querier;
     fn querier(&mut self) -> Self::Q;
     fn on_tick(&mut self, now_ms: u64) -> impl std::future::Future<Output = ()> + Send;
-    fn on_event(&mut self, now_ms: u64, from: NodeId, req_ts: u64, req: connector_request::Request) -> impl std::future::Future<Output = Option<connector_response::Response>> + Send;
+    fn on_event(&mut self, now_ms: u64, from: NodeId, req_ts: u64, req_id: u64, req: connector_request::Request) -> impl std::future::Future<Output = Option<connector_response::Response>> + Send;
     fn pop_hook_event(&mut self) -> Option<(AppId, HookEvent)>;
 }
 
@@ -135,8 +135,8 @@ impl ConnectorStorage {
         }
     }
 
-    pub async fn on_event(&mut self, from: NodeId, ts: u64, req: connector_request::Request) -> Option<connector_response::Response> {
-        let res = self.sql_storage.on_event(now_ms(), from, ts, req).await?;
+    pub async fn on_event(&mut self, from: NodeId, ts: u64, req_id: u64, req: connector_request::Request) -> Option<connector_response::Response> {
+        let res = self.sql_storage.on_event(now_ms(), from, ts, req_id, req).await?;
 
         while let Some((app, event)) = self.sql_storage.pop_hook_event() {
             self.hook.on_event(app, event);

--- a/packages/media_connector/src/sql_storage.rs
+++ b/packages/media_connector/src/sql_storage.rs
@@ -570,7 +570,7 @@ impl Storage for ConnectorSqlStorage {
                 }
 
                 if let Err(e) = self.on_peer_event(now_ms, from, event_ts, &event.app, event.session_id, event.event.clone()?).await {
-                    log::error!("[ConnectorSqlStorage] on_peer_event db error {e:?}");
+                    log::error!("[ConnectorSqlStorage] on_peer_event {event:?} db error {e:?}");
                     return None;
                 }
                 self.hook_events.push_back((


### PR DESCRIPTION
## Pull Request

### Description

When a request send from media to connector but connector failed to process, media-server will try forever. It can be fix by only marked it as processed it it success process on connector

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
