### PR TITLE
fix: missing media-server-secure feature which caused build media-server error

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -9,7 +9,7 @@ description = "Atm0s Media Server"
 
 [dependencies]
 media-server-protocol = { workspace = true, features = ["quinn-rpc"] }
-media-server-secure = { workspace = true }
+media-server-secure = { workspace = true, features = ["jwt-secure"] }
 media-server-console-front = { workspace = true, optional = true }
 media-server-runner = { workspace = true, optional = true }
 media-server-gateway = { workspace = true, optional = true }


### PR DESCRIPTION
## Pull Request

### Description

media-server-secure missed "jwt-secure" feature.

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added appropriate tests, if applicable.

### Screenshots

If applicable, add screenshots to help explain the changes made.

### Additional Notes

Add any additional notes or context about the pull request here.
