### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "atm0s-media-server-connector",
  "atm0s-media-server-console-front",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-codecs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "libsoxr",
  "opusic-sys",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-console-front"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "atm0s-media-server-utils",
  "log",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-record"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "atm0s-media-server-codecs",
  "atm0s-media-server-connector",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-transport-rtpengine"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "atm0s-media-server-codecs",
  "atm0s-media-server-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ media-server-utils = { package = "atm0s-media-server-utils", path = "packages/me
 media-server-core = { package = "atm0s-media-server-core", path = "packages/media_core", version = "0.1.0-alpha.2" }
 media-server-runner = { package = "atm0s-media-server-runner", path = "packages/media_runner", version = "0.1.0-alpha.2" }
 media-server-protocol = { package = "atm0s-media-server-protocol", path = "packages/protocol", version = "0.2.0-alpha.1" }
-media-server-console-front = { package = "atm0s-media-server-console-front", path = "packages/media_console_front", version = "0.1.0-alpha.1" }
+media-server-console-front = { package = "atm0s-media-server-console-front", path = "packages/media_console_front", version = "0.1.0-alpha.2" }
 media-server-connector = { package = "atm0s-media-server-connector", path = "packages/media_connector", version = "0.1.0-alpha.1" }
-media-server-record = { package = "atm0s-media-server-record", path = "packages/media_record", version = "0.1.0-alpha.1", default-features = false }
+media-server-record = { package = "atm0s-media-server-record", path = "packages/media_record", version = "0.1.0-alpha.2", default-features = false }
 media-server-gateway = { package = "atm0s-media-server-gateway", path = "packages/media_gateway", version = "0.1.0-alpha.1" }
 media-server-audio-mixer = { package = "atm0s-media-server-audio-mixer", path = "packages/audio_mixer", version = "0.1.0-alpha.1" }
 media-server-secure = { package = "atm0s-media-server-secure", path = "packages/media_secure", version = "0.1.0-alpha.1", default-features = false }
-media-server-codecs = { package = "atm0s-media-server-codecs", path = "packages/media_codecs", version = "0.1.0-alpha.1", default-features = false }
+media-server-codecs = { package = "atm0s-media-server-codecs", path = "packages/media_codecs", version = "0.1.0-alpha.2", default-features = false }
 media-server-multi-tenancy = { package = "atm0s-media-server-multi-tenancy", path = "packages/multi_tenancy", version = "0.1.0-alpha.1" }
 transport-webrtc = { package = "atm0s-media-server-transport-webrtc", path = "packages/transport_webrtc", version = "0.3.0-alpha.2" }
-transport-rtpengine = { package = "atm0s-media-server-transport-rtpengine", path = "packages/transport_rtpengine", version = "0.1.0-alpha.2" }
+transport-rtpengine = { package = "atm0s-media-server-transport-rtpengine", path = "packages/transport_rtpengine", version = "0.1.0-alpha.3" }
 
 sans-io-runtime = { version = "0.3", default-features = false }
 atm0s-sdn = { version = "0.2", default-features = false }

--- a/bin/CHANGELOG.md
+++ b/bin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.3...v0.2.0-alpha.4) - 2025-02-26
+
+### Added
+
+- simple nodes visualization in console (#509)
+
 ## [0.2.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.2...v0.2.0-alpha.3) - 2025-02-08
 
 ### Other

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_codecs/CHANGELOG.md
+++ b/packages/media_codecs/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-codecs-v0.1.0-alpha.1...atm0s-media-server-codecs-v0.1.0-alpha.2) - 2025-02-26
+
+### Added
+
+- simple nodes visualization in console (#509)

--- a/packages/media_codecs/Cargo.toml
+++ b/packages/media_codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-codecs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_console_front/CHANGELOG.md
+++ b/packages/media_console_front/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.1...atm0s-media-server-console-front-v0.1.0-alpha.2) - 2025-02-26
+
+### Added
+
+- simple nodes visualization in console (#509)

--- a/packages/media_console_front/Cargo.toml
+++ b/packages/media_console_front/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-console-front"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_record/CHANGELOG.md
+++ b/packages/media_record/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.1...atm0s-media-server-record-v0.1.0-alpha.2) - 2025-02-26
+
+### Other
+
+- updated the following local packages: atm0s-media-server-codecs

--- a/packages/media_record/Cargo.toml
+++ b/packages/media_record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-record"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/transport_rtpengine/CHANGELOG.md
+++ b/packages/transport_rtpengine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-rtpengine-v0.1.0-alpha.2...atm0s-media-server-transport-rtpengine-v0.1.0-alpha.3) - 2025-02-26
+
+### Other
+
+- updated the following local packages: atm0s-media-server-codecs
+
 ## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-rtpengine-v0.1.0-alpha.1...atm0s-media-server-transport-rtpengine-v0.1.0-alpha.2) - 2025-02-08
 
 ### Other

--- a/packages/transport_rtpengine/Cargo.toml
+++ b/packages/transport_rtpengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-transport-rtpengine"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `atm0s-media-server-console-front`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)
* `atm0s-media-server-codecs`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)
* `atm0s-media-server`: 0.2.0-alpha.3 -> 0.2.0-alpha.4 (⚠ API breaking changes)
* `atm0s-media-server-record`: 0.1.0-alpha.1 -> 0.1.0-alpha.2
* `atm0s-media-server-transport-rtpengine`: 0.1.0-alpha.2 -> 0.1.0-alpha.3

### ⚠ `atm0s-media-server` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type StorageShared is no longer UnwindSafe, in /tmp/.tmpxphG2K/atm0s-media-server/bin/src/server/console/storage.rs:401
  type StorageShared is no longer RefUnwindSafe, in /tmp/.tmpxphG2K/atm0s-media-server/bin/src/server/console/storage.rs:401
  type StorageShared is no longer UnwindSafe, in /tmp/.tmpxphG2K/atm0s-media-server/bin/src/server/console/storage.rs:401
  type StorageShared is no longer RefUnwindSafe, in /tmp/.tmpxphG2K/atm0s-media-server/bin/src/server/console/storage.rs:401

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Connection.id in /tmp/.tmpxphG2K/atm0s-media-server/bin/src/server/console/storage.rs:14
  field Connection.id in /tmp/.tmpxphG2K/atm0s-media-server/bin/src/server/console/storage.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `atm0s-media-server-console-front`

<blockquote>

## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.1...atm0s-media-server-console-front-v0.1.0-alpha.2) - 2025-02-26

### Added

- simple nodes visualization in console (#509)
</blockquote>

## `atm0s-media-server-codecs`

<blockquote>

## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-codecs-v0.1.0-alpha.1...atm0s-media-server-codecs-v0.1.0-alpha.2) - 2025-02-26

### Added

- simple nodes visualization in console (#509)
</blockquote>

## `atm0s-media-server`

<blockquote>

## [0.2.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.3...v0.2.0-alpha.4) - 2025-02-26

### Added

- simple nodes visualization in console (#509)
</blockquote>

## `atm0s-media-server-record`

<blockquote>

## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.1...atm0s-media-server-record-v0.1.0-alpha.2) - 2025-02-26

### Other

- updated the following local packages: atm0s-media-server-codecs
</blockquote>

## `atm0s-media-server-transport-rtpengine`

<blockquote>

## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-rtpengine-v0.1.0-alpha.2...atm0s-media-server-transport-rtpengine-v0.1.0-alpha.3) - 2025-02-26

### Other

- updated the following local packages: atm0s-media-server-codecs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).