### PR TITLE
chore: release 0.2.0-alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 dependencies = [
  "atm0s-media-server-connector",
  "atm0s-media-server-console-front",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-console-front"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "atm0s-media-server-utils",
  "log",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-record"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "atm0s-media-server-codecs",
  "atm0s-media-server-connector",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-runner"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "atm0s-media-server-connector",
  "atm0s-media-server-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ members = [
 audio-mixer = { package = "atm0s-media-server-audio-mixer", path = "packages/audio_mixer", version = "0.2.0-alpha.1" }
 media-server-utils = { package = "atm0s-media-server-utils", path = "packages/media_utils", version = "0.3.0-alpha.1" }
 media-server-core = { package = "atm0s-media-server-core", path = "packages/media_core", version = "0.1.0-alpha.2" }
-media-server-runner = { package = "atm0s-media-server-runner", path = "packages/media_runner", version = "0.1.0-alpha.2" }
+media-server-runner = { package = "atm0s-media-server-runner", path = "packages/media_runner", version = "0.1.0-alpha.3" }
 media-server-protocol = { package = "atm0s-media-server-protocol", path = "packages/protocol", version = "0.2.0-alpha.1" }
-media-server-console-front = { package = "atm0s-media-server-console-front", path = "packages/media_console_front", version = "0.1.0-alpha.2" }
+media-server-console-front = { package = "atm0s-media-server-console-front", path = "packages/media_console_front", version = "0.1.0-alpha.3" }
 media-server-connector = { package = "atm0s-media-server-connector", path = "packages/media_connector", version = "0.1.0-alpha.1" }
-media-server-record = { package = "atm0s-media-server-record", path = "packages/media_record", version = "0.1.0-alpha.3", default-features = false }
+media-server-record = { package = "atm0s-media-server-record", path = "packages/media_record", version = "0.1.0-alpha.4", default-features = false }
 media-server-gateway = { package = "atm0s-media-server-gateway", path = "packages/media_gateway", version = "0.1.0-alpha.1" }
 media-server-audio-mixer = { package = "atm0s-media-server-audio-mixer", path = "packages/audio_mixer", version = "0.1.0-alpha.1" }
 media-server-secure = { package = "atm0s-media-server-secure", path = "packages/media_secure", version = "0.1.0-alpha.1", default-features = false }

--- a/bin/CHANGELOG.md
+++ b/bin/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.6](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.5...v0.2.0-alpha.6) - 2025-03-02
+
+### Fixed
+
+- wrong worker setting cause cross nodes stream subscribe failed ([#517](https://github.com/8xFF/atm0s-media-server/pull/517))
+
+### Other
+
+- update Cargo.lock dependencies
+- migrate to tailwindcss v4, update layout, router ([#514](https://github.com/8xFF/atm0s-media-server/pull/514))
+
 ## [0.2.0-alpha.5](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.4...v0.2.0-alpha.5) - 2025-02-27
 
 ### Other

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_console_front/CHANGELOG.md
+++ b/packages/media_console_front/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.2...atm0s-media-server-console-front-v0.1.0-alpha.3) - 2025-03-02
+
+### Other
+
+- migrate to tailwindcss v4, update layout, router ([#514](https://github.com/8xFF/atm0s-media-server/pull/514))
+
 ## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.1...atm0s-media-server-console-front-v0.1.0-alpha.2) - 2025-02-26
 
 ### Added

--- a/packages/media_console_front/Cargo.toml
+++ b/packages/media_console_front/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-console-front"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_record/CHANGELOG.md
+++ b/packages/media_record/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.3...atm0s-media-server-record-v0.1.0-alpha.4) - 2025-03-02
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.2...atm0s-media-server-record-v0.1.0-alpha.3) - 2025-02-27
 
 ### Other

--- a/packages/media_record/Cargo.toml
+++ b/packages/media_record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-record"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_runner/CHANGELOG.md
+++ b/packages/media_runner/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.2...atm0s-media-server-runner-v0.1.0-alpha.3) - 2025-03-02
+
+### Fixed
+
+- wrong worker setting cause cross nodes stream subscribe failed ([#517](https://github.com/8xFF/atm0s-media-server/pull/517))
+
 ## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.1...atm0s-media-server-runner-v0.1.0-alpha.2) - 2025-02-08
 
 ### Other

--- a/packages/media_runner/Cargo.toml
+++ b/packages/media_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-runner"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `atm0s-media-server-console-front`: 0.1.0-alpha.2 -> 0.1.0-alpha.3 (✓ API compatible changes)
* `atm0s-media-server-record`: 0.1.0-alpha.3 -> 0.1.0-alpha.4 (✓ API compatible changes)
* `atm0s-media-server-runner`: 0.1.0-alpha.2 -> 0.1.0-alpha.3 (✓ API compatible changes)
* `atm0s-media-server`: 0.2.0-alpha.5 -> 0.2.0-alpha.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `atm0s-media-server-console-front`

<blockquote>

## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.2...atm0s-media-server-console-front-v0.1.0-alpha.3) - 2025-03-02

### Other

- migrate to tailwindcss v4, update layout, router ([#514](https://github.com/8xFF/atm0s-media-server/pull/514))
</blockquote>

## `atm0s-media-server-record`

<blockquote>

## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.3...atm0s-media-server-record-v0.1.0-alpha.4) - 2025-03-02

### Other

- update Cargo.lock dependencies
</blockquote>

## `atm0s-media-server-runner`

<blockquote>

## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.2...atm0s-media-server-runner-v0.1.0-alpha.3) - 2025-03-02

### Fixed

- wrong worker setting cause cross nodes stream subscribe failed ([#517](https://github.com/8xFF/atm0s-media-server/pull/517))
</blockquote>

## `atm0s-media-server`

<blockquote>

## [0.2.0-alpha.6](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.5...v0.2.0-alpha.6) - 2025-03-02

### Fixed

- wrong worker setting cause cross nodes stream subscribe failed ([#517](https://github.com/8xFF/atm0s-media-server/pull/517))

### Other

- update Cargo.lock dependencies
- migrate to tailwindcss v4, update layout, router ([#514](https://github.com/8xFF/atm0s-media-server/pull/514))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).