### PR TITLE
fix: avoid crash when media pkt after remote track ended

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -58,7 +58,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Install required cargo
-        run: cargo install clippy-sarif sarif-fmt
+        run: cargo install --locked clippy-sarif sarif-fmt
 
       - name: Run rust-sarif
         run: cargo clippy --all-features --message-format=json |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check
           log-level: error

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check
+          command: check bans licenses sources
           log-level: error
           arguments: --all-features --target ${{ matrix.platform }}

--- a/deny.toml
+++ b/deny.toml
@@ -61,6 +61,7 @@ allow = [
   "Zlib",                                   # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
   "LGPL-2.0",                               # https://www.gnu.org/licenses/old-licenses/lgpl-2.0.en.html
   "X11",                                    # https://en.wikipedia.org/wiki/MIT_License
+  "X11-swapped",                            # https://spdx.org/licenses/X11-swapped.html
   "X11-distribute-modifications-variant",   # https://spdx.org/licenses/X11-distribute-modifications-variant.html
   "Unicode-3.0",                            # https://spdx.org/licenses/Unicode-3.0.html
   "Unlicense",                              # https://unlicense.org/

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,7 @@
 # Install: `cargo install cargo-deny`
 # Check: `cargo deny check` or run `cargo_deny.sh`.
 
+[graph]
 # Note: running just `cargo deny check` without a `--target` can result in
 # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
 targets = [
@@ -26,9 +27,6 @@ targets = [
 ]
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "deny"
 ignore = [
     "RUSTSEC-2023-0071", # a new version of rsa has not been released
     "RUSTSEC-2024-0363" # a new version of sqlx has not been released
@@ -44,11 +42,7 @@ skip-tree = []
 
 
 [licenses]
-private = { ignore = true }
-unlicensed = "allow"
-allow-osi-fsf-free = "neither"
 confidence-threshold = 0.92 # We want really high confidence when inferring licenses from text
-copyleft = "deny"
 allow = [
   "Apache-2.0 WITH LLVM-exception",         # https://spdx.org/licenses/LLVM-exception.html
   "Apache-2.0",                             # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
@@ -71,3 +65,6 @@ allow = [
   "Unicode-3.0",                            # https://spdx.org/licenses/Unicode-3.0.html
   "Unlicense",                              # https://unlicense.org/
 ]
+
+[licenses.private]
+ignore = true

--- a/packages/media_runner/src/worker.rs
+++ b/packages/media_runner/src/worker.rs
@@ -371,6 +371,10 @@ impl<ES: 'static + MediaEdgeSecure> MediaServerWorker<ES> {
     }
 
     pub fn on_shutdown(&mut self, now: Instant) {
+        if self.shutdown {
+            return;
+        }
+        self.shutdown = true;
         let now_ms = self.timer.timestamp_ms(now);
         self.sdn_worker.input(&mut self.switcher).on_shutdown(now_ms);
         self.media_cluster.input(&mut self.switcher).shutdown(now);

--- a/packages/transport_webrtc/src/transport/webrtc.rs
+++ b/packages/transport_webrtc/src/transport/webrtc.rs
@@ -161,8 +161,8 @@ impl<ES> TransportWebrtcSdk<ES> {
         self.remote_tracks.iter_mut().find(|t| t.id() == track_id)
     }
 
-    fn remote_track_by_mid(&mut self, mid: Mid) -> Option<&mut RemoteTrack> {
-        self.remote_tracks.iter_mut().find(|t| t.mid() == Some(mid))
+    fn remote_track_by_mid_with_source(&mut self, mid: Mid) -> Option<&mut RemoteTrack> {
+        self.remote_tracks.iter_mut().find(|t| t.mid() == Some(mid) && t.has_source())
     }
 
     fn remote_track_by_name(&mut self, name: &str) -> Option<&mut RemoteTrack> {
@@ -545,7 +545,7 @@ impl<ES: MediaEdgeSecure> TransportWebrtcInternal for TransportWebrtcSdk<ES> {
             }
             Str0mEvent::RtpPacket(pkt) => {
                 let mid = return_if_none!(self.media_convert.get_mid(pkt.header.ssrc, pkt.header.ext_vals.mid));
-                let track = return_if_none!(self.remote_track_by_mid(mid)).id();
+                let track = return_if_none!(self.remote_track_by_mid_with_source(mid)).id();
                 let pkt = return_if_none!(self.media_convert.convert(pkt));
                 log::trace!(
                     "[TransportWebrtcSdk] incoming pkt codec {:?}, seq {} ts {}, marker {}, payload {}",
@@ -565,7 +565,7 @@ impl<ES: MediaEdgeSecure> TransportWebrtcInternal for TransportWebrtcSdk<ES> {
                 // without it, sometime we will failed to restore session from restart-ice
                 self.media_convert.get_mid(event.ssrc, Some(event.mid));
 
-                let track = return_if_none!(self.remote_track_by_mid(event.mid)).name().to_string();
+                let track = return_if_none!(self.remote_track_by_mid_with_source(event.mid)).name().to_string();
                 let status = if event.paused {
                     ProtoSenderStatus::Inactive
                 } else {

--- a/packages/transport_webrtc/src/transport/webrtc.rs
+++ b/packages/transport_webrtc/src/transport/webrtc.rs
@@ -545,20 +545,8 @@ impl<ES: MediaEdgeSecure> TransportWebrtcInternal for TransportWebrtcSdk<ES> {
             }
             Str0mEvent::RtpPacket(pkt) => {
                 let mid = return_if_none!(self.media_convert.get_mid(pkt.header.ssrc, pkt.header.ext_vals.mid));
-                let track = return_if_none!(self.remote_track_by_mid_with_source(mid)).id();
                 let pkt = return_if_none!(self.media_convert.convert(pkt));
-                log::trace!(
-                    "[TransportWebrtcSdk] incoming pkt codec {:?}, seq {} ts {}, marker {}, payload {}",
-                    pkt.meta,
-                    pkt.seq,
-                    pkt.ts,
-                    pkt.marker,
-                    pkt.data.len(),
-                );
-                self.queue.push_back(InternalOutput::TransportOutput(TransportOutput::Event(TransportEvent::RemoteTrack(
-                    track,
-                    RemoteTrackEvent::Media(pkt),
-                ))));
+                self.on_remote_track_media(mid, pkt);
             }
             Str0mEvent::StreamPaused(event) => {
                 // We need to map media ssrc here for avoiding unknown pkt
@@ -612,6 +600,22 @@ impl<ES: MediaEdgeSecure> TransportWebrtcInternal for TransportWebrtcSdk<ES> {
 }
 
 impl<ES: MediaEdgeSecure> TransportWebrtcSdk<ES> {
+    fn on_remote_track_media(&mut self, mid: Mid, pkt: media_server_protocol::media::MediaPacket) {
+        let track = return_if_none!(self.remote_track_by_mid_with_source(mid)).id();
+        log::trace!(
+            "[TransportWebrtcSdk] incoming pkt codec {:?}, seq {} ts {}, marker {}, payload {}",
+            pkt.meta,
+            pkt.seq,
+            pkt.ts,
+            pkt.marker,
+            pkt.data.len(),
+        );
+        self.queue.push_back(InternalOutput::TransportOutput(TransportOutput::Event(TransportEvent::RemoteTrack(
+            track,
+            RemoteTrackEvent::Media(pkt),
+        ))));
+    }
+
     fn on_str0m_state(&mut self, now: Instant, state: IceConnectionState) {
         log::info!("[TransportWebrtcSdk] str0m state changed {:?}", state);
 
@@ -917,10 +921,11 @@ mod tests {
 
     use media_server_core::{
         endpoint::EndpointReq,
-        transport::{TransportError, TransportEvent, TransportOutput, TransportState},
+        transport::{RemoteTrackEvent, TransportError, TransportEvent, TransportOutput, TransportState},
     };
     use media_server_protocol::{
         endpoint::{PeerMeta, RoomInfoPublish, RoomInfoSubscribe},
+        media::MediaPacket,
         multi_tenancy::{AppContext, AppId},
         protobuf::{
             self, gateway,
@@ -935,7 +940,10 @@ mod tests {
         DumpAppStorage, MediaGatewaySecure,
     };
     use prost::Message;
-    use str0m::channel::ChannelId;
+    use str0m::{
+        channel::ChannelId,
+        media::{Direction, MediaAdded, MediaKind as Str0mMediaKind, Mid},
+    };
 
     use crate::{
         transport::{webrtc::TIMEOUT_SEC, InternalOutput, TransportWebrtcInternal},
@@ -1225,6 +1233,87 @@ mod tests {
         );
         assert_eq!(transport.pop_output(now), None);
         assert!(transport.is_empty());
+    }
+
+    #[test]
+    fn detached_remote_track_should_not_emit_media_packets() {
+        let app = AppContext::root_app();
+        let req = gateway::ConnectRequest {
+            tracks: Some(protobuf::shared::Tracks {
+                receivers: vec![],
+                senders: vec![protobuf::shared::Sender {
+                    kind: protobuf::shared::Kind::Audio as i32,
+                    name: "audio_main".to_string(),
+                    state: Some(protobuf::shared::sender::State {
+                        config: None,
+                        source: Some(protobuf::shared::sender::Source {
+                            id: "source-1".to_string(),
+                            screen: false,
+                            metadata: None,
+                        }),
+                    }),
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let now = Instant::now();
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let secure_jwt = Arc::new(MediaEdgeSecureJwt::from(b"1234".as_slice()));
+        let channel_id = create_channel_id();
+        let mut transport = TransportWebrtcSdk::new(app, req, Some("extra_data".to_string()), secure_jwt, ip);
+
+        transport.on_str0m_event(now, str0m::Event::ChannelOpen(channel_id, "data".to_string()));
+        assert_eq!(
+            transport.pop_output(now),
+            Some(InternalOutput::TransportOutput(TransportOutput::Event(TransportEvent::State(TransportState::Connected(ip)))))
+        );
+
+        let mid = Mid::new();
+        transport.on_str0m_event(
+            now,
+            str0m::Event::MediaAdded(MediaAdded {
+                mid,
+                kind: Str0mMediaKind::Audio,
+                direction: Direction::RecvOnly,
+                simulcast: None,
+            }),
+        );
+        assert!(matches!(
+            transport.pop_output(now),
+            Some(InternalOutput::TransportOutput(TransportOutput::Event(TransportEvent::RemoteTrack(
+                _,
+                RemoteTrackEvent::Started { .. }
+            ))))
+        ));
+        assert!(transport.remote_track_by_mid_with_source(mid).is_some());
+
+        transport.on_remote_track_media(mid, MediaPacket::build_audio(1000, 1, None, vec![0xAA]));
+        assert!(matches!(
+            transport.pop_output(now),
+            Some(InternalOutput::TransportOutput(TransportOutput::Event(TransportEvent::RemoteTrack(_, RemoteTrackEvent::Media(_)))))
+        ));
+
+        transport.on_str0m_channel_event(ClientEvent {
+            seq: 0,
+            event: Some(client_event::Event::Request(session::Request {
+                req_id: 11,
+                request: Some(session::request::Request::Sender(session::request::Sender {
+                    name: "audio_main".to_string(),
+                    request: Some(session::request::sender::Request::Detach(session::request::sender::Detach {})),
+                })),
+            })),
+        });
+
+        assert!(matches!(transport.pop_output(now), Some(InternalOutput::Str0mSendData(_, _))));
+        assert_eq!(
+            transport.pop_output(now),
+            Some(InternalOutput::TransportOutput(TransportOutput::Event(TransportEvent::RemoteTrack(0.into(), RemoteTrackEvent::Ended,))))
+        );
+
+        transport.on_remote_track_media(mid, MediaPacket::build_audio(1001, 2, None, vec![0xBB]));
+        assert_eq!(transport.pop_output(now), None);
+        assert!(transport.remote_track_by_mid_with_source(mid).is_none());
     }
 
     //TODO test remote track non-source


### PR DESCRIPTION
## Pull Request

### Description

This PR fix crash in special case where remote track still output some media pkt after sent end command

### Related Issue

If this pull request is related to any issue, please mention it here.

### Checklist

- [x] I have tested the changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate tests, if applicable.