### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.7"
+version = "0.2.0-alpha.8"
 dependencies = [
  "atm0s-media-server-connector",
  "atm0s-media-server-console-front",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-runner"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "atm0s-media-server-connector",
  "atm0s-media-server-core",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-transport-webrtc"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 dependencies = [
  "atm0s-media-server-core",
  "atm0s-media-server-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 audio-mixer = { package = "atm0s-media-server-audio-mixer", path = "packages/audio_mixer", version = "0.2.0-alpha.1" }
 media-server-utils = { package = "atm0s-media-server-utils", path = "packages/media_utils", version = "0.3.0-alpha.1" }
 media-server-core = { package = "atm0s-media-server-core", path = "packages/media_core", version = "0.1.0-alpha.2" }
-media-server-runner = { package = "atm0s-media-server-runner", path = "packages/media_runner", version = "0.1.0-alpha.3" }
+media-server-runner = { package = "atm0s-media-server-runner", path = "packages/media_runner", version = "0.1.0-alpha.4" }
 media-server-protocol = { package = "atm0s-media-server-protocol", path = "packages/protocol", version = "0.2.0-alpha.1" }
 media-server-console-front = { package = "atm0s-media-server-console-front", path = "packages/media_console_front", version = "0.1.0-alpha.3" }
 media-server-connector = { package = "atm0s-media-server-connector", path = "packages/media_connector", version = "0.1.0-alpha.1" }
@@ -33,7 +33,7 @@ media-server-audio-mixer = { package = "atm0s-media-server-audio-mixer", path = 
 media-server-secure = { package = "atm0s-media-server-secure", path = "packages/media_secure", version = "0.1.0-alpha.1", default-features = false }
 media-server-codecs = { package = "atm0s-media-server-codecs", path = "packages/media_codecs", version = "0.1.0-alpha.2", default-features = false }
 media-server-multi-tenancy = { package = "atm0s-media-server-multi-tenancy", path = "packages/multi_tenancy", version = "0.1.0-alpha.1" }
-transport-webrtc = { package = "atm0s-media-server-transport-webrtc", path = "packages/transport_webrtc", version = "0.3.0-alpha.2" }
+transport-webrtc = { package = "atm0s-media-server-transport-webrtc", path = "packages/transport_webrtc", version = "0.3.0-alpha.3" }
 transport-rtpengine = { package = "atm0s-media-server-transport-rtpengine", path = "packages/transport_rtpengine", version = "0.1.0-alpha.3" }
 
 sans-io-runtime = { version = "0.3", default-features = false }

--- a/bin/CHANGELOG.md
+++ b/bin/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.8](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.7...v0.2.0-alpha.8) - 2026-04-23
+
+### Fixed
+
+- avoid crash when media pkt after remote track ended ([#542](https://github.com/8xFF/atm0s-media-server/pull/542))
+
 ## [0.2.0-alpha.7](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.6...v0.2.0-alpha.7) - 2025-03-02
 
 ### Fixed

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.7"
+version = "0.2.0-alpha.8"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_runner/CHANGELOG.md
+++ b/packages/media_runner/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.3...atm0s-media-server-runner-v0.1.0-alpha.4) - 2026-04-23
+
+### Fixed
+
+- avoid crash when media pkt after remote track ended ([#542](https://github.com/8xFF/atm0s-media-server/pull/542))
+
 ## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.2...atm0s-media-server-runner-v0.1.0-alpha.3) - 2025-03-02
 
 ### Fixed

--- a/packages/media_runner/Cargo.toml
+++ b/packages/media_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-runner"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/transport_webrtc/CHANGELOG.md
+++ b/packages/transport_webrtc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-webrtc-v0.3.0-alpha.2...atm0s-media-server-transport-webrtc-v0.3.0-alpha.3) - 2026-04-23
+
+### Fixed
+
+- avoid crash when media pkt after remote track ended ([#542](https://github.com/8xFF/atm0s-media-server/pull/542))
+
 ## [0.3.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-webrtc-v0.3.0-alpha.1...atm0s-media-server-transport-webrtc-v0.3.0-alpha.2) - 2025-02-08
 
 ### Other

--- a/packages/transport_webrtc/Cargo.toml
+++ b/packages/transport_webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-transport-webrtc"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `atm0s-media-server-transport-webrtc`: 0.3.0-alpha.2 -> 0.3.0-alpha.3 (✓ API compatible changes)
* `atm0s-media-server-runner`: 0.1.0-alpha.3 -> 0.1.0-alpha.4 (✓ API compatible changes)
* `atm0s-media-server`: 0.2.0-alpha.7 -> 0.2.0-alpha.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `atm0s-media-server-transport-webrtc`

<blockquote>

## [0.3.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-webrtc-v0.3.0-alpha.2...atm0s-media-server-transport-webrtc-v0.3.0-alpha.3) - 2026-04-23

### Fixed

- avoid crash when media pkt after remote track ended ([#542](https://github.com/8xFF/atm0s-media-server/pull/542))
</blockquote>

## `atm0s-media-server-runner`

<blockquote>

## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.3...atm0s-media-server-runner-v0.1.0-alpha.4) - 2026-04-23

### Fixed

- avoid crash when media pkt after remote track ended ([#542](https://github.com/8xFF/atm0s-media-server/pull/542))
</blockquote>

## `atm0s-media-server`

<blockquote>

## [0.2.0-alpha.8](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.7...v0.2.0-alpha.8) - 2026-04-23

### Fixed

- avoid crash when media pkt after remote track ended ([#542](https://github.com/8xFF/atm0s-media-server/pull/542))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).