### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.8"
+version = "0.2.0-alpha.9"
 dependencies = [
  "atm0s-media-server-connector",
  "atm0s-media-server-console-front",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-connector"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "atm0s-media-server-multi-tenancy",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-console-front"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "atm0s-media-server-utils",
  "log",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-core"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "atm0s-media-server-audio-mixer",
  "atm0s-media-server-protocol",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-record"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "atm0s-media-server-codecs",
  "atm0s-media-server-connector",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-runner"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "atm0s-media-server-connector",
  "atm0s-media-server-core",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-transport-rtpengine"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "atm0s-media-server-codecs",
  "atm0s-media-server-core",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-transport-webrtc"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 dependencies = [
  "atm0s-media-server-core",
  "atm0s-media-server-protocol",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "atm0s-media-server-utils"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,20 +21,20 @@ members = [
 
 [workspace.dependencies]
 audio-mixer = { package = "atm0s-media-server-audio-mixer", path = "packages/audio_mixer", version = "0.2.0-alpha.1" }
-media-server-utils = { package = "atm0s-media-server-utils", path = "packages/media_utils", version = "0.3.0-alpha.1" }
-media-server-core = { package = "atm0s-media-server-core", path = "packages/media_core", version = "0.1.0-alpha.2" }
-media-server-runner = { package = "atm0s-media-server-runner", path = "packages/media_runner", version = "0.1.0-alpha.4" }
+media-server-utils = { package = "atm0s-media-server-utils", path = "packages/media_utils", version = "0.3.0-alpha.2" }
+media-server-core = { package = "atm0s-media-server-core", path = "packages/media_core", version = "0.1.0-alpha.3" }
+media-server-runner = { package = "atm0s-media-server-runner", path = "packages/media_runner", version = "0.1.0-alpha.5" }
 media-server-protocol = { package = "atm0s-media-server-protocol", path = "packages/protocol", version = "0.2.0-alpha.1" }
-media-server-console-front = { package = "atm0s-media-server-console-front", path = "packages/media_console_front", version = "0.1.0-alpha.3" }
-media-server-connector = { package = "atm0s-media-server-connector", path = "packages/media_connector", version = "0.1.0-alpha.1" }
-media-server-record = { package = "atm0s-media-server-record", path = "packages/media_record", version = "0.1.0-alpha.4", default-features = false }
+media-server-console-front = { package = "atm0s-media-server-console-front", path = "packages/media_console_front", version = "0.1.0-alpha.4" }
+media-server-connector = { package = "atm0s-media-server-connector", path = "packages/media_connector", version = "0.1.0-alpha.2" }
+media-server-record = { package = "atm0s-media-server-record", path = "packages/media_record", version = "0.1.0-alpha.5", default-features = false }
 media-server-gateway = { package = "atm0s-media-server-gateway", path = "packages/media_gateway", version = "0.1.0-alpha.1" }
 media-server-audio-mixer = { package = "atm0s-media-server-audio-mixer", path = "packages/audio_mixer", version = "0.1.0-alpha.1" }
 media-server-secure = { package = "atm0s-media-server-secure", path = "packages/media_secure", version = "0.1.0-alpha.1", default-features = false }
 media-server-codecs = { package = "atm0s-media-server-codecs", path = "packages/media_codecs", version = "0.1.0-alpha.2", default-features = false }
 media-server-multi-tenancy = { package = "atm0s-media-server-multi-tenancy", path = "packages/multi_tenancy", version = "0.1.0-alpha.1" }
-transport-webrtc = { package = "atm0s-media-server-transport-webrtc", path = "packages/transport_webrtc", version = "0.3.0-alpha.3" }
-transport-rtpengine = { package = "atm0s-media-server-transport-rtpengine", path = "packages/transport_rtpengine", version = "0.1.0-alpha.3" }
+transport-webrtc = { package = "atm0s-media-server-transport-webrtc", path = "packages/transport_webrtc", version = "0.3.0-alpha.4" }
+transport-rtpengine = { package = "atm0s-media-server-transport-rtpengine", path = "packages/transport_rtpengine", version = "0.1.0-alpha.4" }
 
 sans-io-runtime = { version = "0.3", default-features = false }
 atm0s-sdn = { version = "0.2", default-features = false }

--- a/bin/CHANGELOG.md
+++ b/bin/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.9](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.8...v0.2.0-alpha.9) - 2026-05-18
+
+### Added
+
+- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))
+
+### Fixed
+
+- webm seek issue ([#550](https://github.com/8xFF/atm0s-media-server/pull/550))
+
+### Other
+
+- *(deps)* update dependency js-cookie to v3.0.7 ([#551](https://github.com/8xFF/atm0s-media-server/pull/551))
+- *(deps)* update dependency axios to v1.15.2 [security] ([#488](https://github.com/8xFF/atm0s-media-server/pull/488))
+- *(deps)* update dependency @types/lodash to v4.17.24 ([#489](https://github.com/8xFF/atm0s-media-server/pull/489))
+- *(deps)* update dependency @vitejs/plugin-react to v4.7.0 ([#512](https://github.com/8xFF/atm0s-media-server/pull/512))
+- *(deps)* update dependency @radix-ui/react-icons to v1.3.2 ([#537](https://github.com/8xFF/atm0s-media-server/pull/537))
+- *(deps)* update dependency lodash to v4.18.1 [security] ([#535](https://github.com/8xFF/atm0s-media-server/pull/535))
+- *(deps)* update dependency class-variance-authority to v0.7.1 ([#538](https://github.com/8xFF/atm0s-media-server/pull/538))
+- *(deps)* update dependency dayjs to v1.11.20 ([#539](https://github.com/8xFF/atm0s-media-server/pull/539))
+- *(deps)* update dependency postcss to v8.5.10 [security] ([#549](https://github.com/8xFF/atm0s-media-server/pull/549))
+- *(deps)* update dependency react-resizable-panels to v2.1.9 ([#546](https://github.com/8xFF/atm0s-media-server/pull/546))
+
 ## [0.2.0-alpha.8](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.7...v0.2.0-alpha.8) - 2026-04-23
 
 ### Fixed

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server"
-version = "0.2.0-alpha.8"
+version = "0.2.0-alpha.9"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_connector/CHANGELOG.md
+++ b/packages/media_connector/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-connector-v0.1.0-alpha.1...atm0s-media-server-connector-v0.1.0-alpha.2) - 2026-05-18
+
+### Added
+
+- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))

--- a/packages/media_connector/Cargo.toml
+++ b/packages/media_connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-connector"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_console_front/CHANGELOG.md
+++ b/packages/media_console_front/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.3...atm0s-media-server-console-front-v0.1.0-alpha.4) - 2026-05-18
+
+### Other
+
+- *(deps)* update dependency js-cookie to v3.0.7 ([#551](https://github.com/8xFF/atm0s-media-server/pull/551))
+- *(deps)* update dependency axios to v1.15.2 [security] ([#488](https://github.com/8xFF/atm0s-media-server/pull/488))
+- *(deps)* update dependency @types/lodash to v4.17.24 ([#489](https://github.com/8xFF/atm0s-media-server/pull/489))
+- *(deps)* update dependency @vitejs/plugin-react to v4.7.0 ([#512](https://github.com/8xFF/atm0s-media-server/pull/512))
+- *(deps)* update dependency @radix-ui/react-icons to v1.3.2 ([#537](https://github.com/8xFF/atm0s-media-server/pull/537))
+- *(deps)* update dependency lodash to v4.18.1 [security] ([#535](https://github.com/8xFF/atm0s-media-server/pull/535))
+- *(deps)* update dependency class-variance-authority to v0.7.1 ([#538](https://github.com/8xFF/atm0s-media-server/pull/538))
+- *(deps)* update dependency dayjs to v1.11.20 ([#539](https://github.com/8xFF/atm0s-media-server/pull/539))
+- *(deps)* update dependency postcss to v8.5.10 [security] ([#549](https://github.com/8xFF/atm0s-media-server/pull/549))
+- *(deps)* update dependency react-resizable-panels to v2.1.9 ([#546](https://github.com/8xFF/atm0s-media-server/pull/546))
+
 ## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.2...atm0s-media-server-console-front-v0.1.0-alpha.3) - 2025-03-02
 
 ### Other

--- a/packages/media_console_front/Cargo.toml
+++ b/packages/media_console_front/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-console-front"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_core/CHANGELOG.md
+++ b/packages/media_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-core-v0.1.0-alpha.2...atm0s-media-server-core-v0.1.0-alpha.3) - 2026-05-18
+
+### Other
+
+- updated the following local packages: atm0s-media-server-utils
+
 ## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-core-v0.1.0-alpha.1...atm0s-media-server-core-v0.1.0-alpha.2) - 2025-02-08
 
 ### Other

--- a/packages/media_core/Cargo.toml
+++ b/packages/media_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-core"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_record/CHANGELOG.md
+++ b/packages/media_record/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.4...atm0s-media-server-record-v0.1.0-alpha.5) - 2026-05-18
+
+### Added
+
+- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))
+
+### Fixed
+
+- webm seek issue ([#550](https://github.com/8xFF/atm0s-media-server/pull/550))
+
 ## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.3...atm0s-media-server-record-v0.1.0-alpha.4) - 2025-03-02
 
 ### Other

--- a/packages/media_record/Cargo.toml
+++ b/packages/media_record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-record"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_runner/CHANGELOG.md
+++ b/packages/media_runner/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.4...atm0s-media-server-runner-v0.1.0-alpha.5) - 2026-05-18
+
+### Other
+
+- updated the following local packages: atm0s-media-server-connector, atm0s-media-server-core, atm0s-media-server-transport-rtpengine, atm0s-media-server-transport-webrtc
+
 ## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.3...atm0s-media-server-runner-v0.1.0-alpha.4) - 2026-04-23
 
 ### Fixed

--- a/packages/media_runner/Cargo.toml
+++ b/packages/media_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-runner"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/media_utils/CHANGELOG.md
+++ b/packages/media_utils/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-utils-v0.3.0-alpha.1...atm0s-media-server-utils-v0.3.0-alpha.2) - 2026-05-18
+
+### Added
+
+- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))

--- a/packages/media_utils/Cargo.toml
+++ b/packages/media_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-utils"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/transport_rtpengine/CHANGELOG.md
+++ b/packages/transport_rtpengine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-rtpengine-v0.1.0-alpha.3...atm0s-media-server-transport-rtpengine-v0.1.0-alpha.4) - 2026-05-18
+
+### Other
+
+- updated the following local packages: atm0s-media-server-utils, atm0s-media-server-core
+
 ## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-rtpengine-v0.1.0-alpha.2...atm0s-media-server-transport-rtpengine-v0.1.0-alpha.3) - 2025-02-26
 
 ### Other

--- a/packages/transport_rtpengine/Cargo.toml
+++ b/packages/transport_rtpengine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-transport-rtpengine"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/transport_webrtc/CHANGELOG.md
+++ b/packages/transport_webrtc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-webrtc-v0.3.0-alpha.3...atm0s-media-server-transport-webrtc-v0.3.0-alpha.4) - 2026-05-18
+
+### Other
+
+- updated the following local packages: atm0s-media-server-utils, atm0s-media-server-core
+
 ## [0.3.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-webrtc-v0.3.0-alpha.2...atm0s-media-server-transport-webrtc-v0.3.0-alpha.3) - 2026-04-23
 
 ### Fixed

--- a/packages/transport_webrtc/Cargo.toml
+++ b/packages/transport_webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atm0s-media-server-transport-webrtc"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 authors = ["Giang Minh <giang.ndm@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `atm0s-media-server-utils`: 0.3.0-alpha.1 -> 0.3.0-alpha.2 (✓ API compatible changes)
* `atm0s-media-server-connector`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)
* `atm0s-media-server-console-front`: 0.1.0-alpha.3 -> 0.1.0-alpha.4 (✓ API compatible changes)
* `atm0s-media-server-record`: 0.1.0-alpha.4 -> 0.1.0-alpha.5 (✓ API compatible changes)
* `atm0s-media-server`: 0.2.0-alpha.8 -> 0.2.0-alpha.9 (✓ API compatible changes)
* `atm0s-media-server-core`: 0.1.0-alpha.2 -> 0.1.0-alpha.3
* `atm0s-media-server-transport-rtpengine`: 0.1.0-alpha.3 -> 0.1.0-alpha.4
* `atm0s-media-server-transport-webrtc`: 0.3.0-alpha.3 -> 0.3.0-alpha.4
* `atm0s-media-server-runner`: 0.1.0-alpha.4 -> 0.1.0-alpha.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `atm0s-media-server-utils`

<blockquote>

## [0.3.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-utils-v0.3.0-alpha.1...atm0s-media-server-utils-v0.3.0-alpha.2) - 2026-05-18

### Added

- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))
</blockquote>

## `atm0s-media-server-connector`

<blockquote>

## [0.1.0-alpha.2](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-connector-v0.1.0-alpha.1...atm0s-media-server-connector-v0.1.0-alpha.2) - 2026-05-18

### Added

- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))
</blockquote>

## `atm0s-media-server-console-front`

<blockquote>

## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-console-front-v0.1.0-alpha.3...atm0s-media-server-console-front-v0.1.0-alpha.4) - 2026-05-18

### Other

- *(deps)* update dependency js-cookie to v3.0.7 ([#551](https://github.com/8xFF/atm0s-media-server/pull/551))
- *(deps)* update dependency axios to v1.15.2 [security] ([#488](https://github.com/8xFF/atm0s-media-server/pull/488))
- *(deps)* update dependency @types/lodash to v4.17.24 ([#489](https://github.com/8xFF/atm0s-media-server/pull/489))
- *(deps)* update dependency @vitejs/plugin-react to v4.7.0 ([#512](https://github.com/8xFF/atm0s-media-server/pull/512))
- *(deps)* update dependency @radix-ui/react-icons to v1.3.2 ([#537](https://github.com/8xFF/atm0s-media-server/pull/537))
- *(deps)* update dependency lodash to v4.18.1 [security] ([#535](https://github.com/8xFF/atm0s-media-server/pull/535))
- *(deps)* update dependency class-variance-authority to v0.7.1 ([#538](https://github.com/8xFF/atm0s-media-server/pull/538))
- *(deps)* update dependency dayjs to v1.11.20 ([#539](https://github.com/8xFF/atm0s-media-server/pull/539))
- *(deps)* update dependency postcss to v8.5.10 [security] ([#549](https://github.com/8xFF/atm0s-media-server/pull/549))
- *(deps)* update dependency react-resizable-panels to v2.1.9 ([#546](https://github.com/8xFF/atm0s-media-server/pull/546))
</blockquote>

## `atm0s-media-server-record`

<blockquote>

## [0.1.0-alpha.5](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-record-v0.1.0-alpha.4...atm0s-media-server-record-v0.1.0-alpha.5) - 2026-05-18

### Added

- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))

### Fixed

- webm seek issue ([#550](https://github.com/8xFF/atm0s-media-server/pull/550))
</blockquote>

## `atm0s-media-server`

<blockquote>

## [0.2.0-alpha.9](https://github.com/8xFF/atm0s-media-server/compare/v0.2.0-alpha.8...v0.2.0-alpha.9) - 2026-05-18

### Added

- custom s3 presign lib for compatible with recording ([#547](https://github.com/8xFF/atm0s-media-server/pull/547))

### Fixed

- webm seek issue ([#550](https://github.com/8xFF/atm0s-media-server/pull/550))

### Other

- *(deps)* update dependency js-cookie to v3.0.7 ([#551](https://github.com/8xFF/atm0s-media-server/pull/551))
- *(deps)* update dependency axios to v1.15.2 [security] ([#488](https://github.com/8xFF/atm0s-media-server/pull/488))
- *(deps)* update dependency @types/lodash to v4.17.24 ([#489](https://github.com/8xFF/atm0s-media-server/pull/489))
- *(deps)* update dependency @vitejs/plugin-react to v4.7.0 ([#512](https://github.com/8xFF/atm0s-media-server/pull/512))
- *(deps)* update dependency @radix-ui/react-icons to v1.3.2 ([#537](https://github.com/8xFF/atm0s-media-server/pull/537))
- *(deps)* update dependency lodash to v4.18.1 [security] ([#535](https://github.com/8xFF/atm0s-media-server/pull/535))
- *(deps)* update dependency class-variance-authority to v0.7.1 ([#538](https://github.com/8xFF/atm0s-media-server/pull/538))
- *(deps)* update dependency dayjs to v1.11.20 ([#539](https://github.com/8xFF/atm0s-media-server/pull/539))
- *(deps)* update dependency postcss to v8.5.10 [security] ([#549](https://github.com/8xFF/atm0s-media-server/pull/549))
- *(deps)* update dependency react-resizable-panels to v2.1.9 ([#546](https://github.com/8xFF/atm0s-media-server/pull/546))
</blockquote>

## `atm0s-media-server-core`

<blockquote>

## [0.1.0-alpha.3](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-core-v0.1.0-alpha.2...atm0s-media-server-core-v0.1.0-alpha.3) - 2026-05-18

### Other

- updated the following local packages: atm0s-media-server-utils
</blockquote>

## `atm0s-media-server-transport-rtpengine`

<blockquote>

## [0.1.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-rtpengine-v0.1.0-alpha.3...atm0s-media-server-transport-rtpengine-v0.1.0-alpha.4) - 2026-05-18

### Other

- updated the following local packages: atm0s-media-server-utils, atm0s-media-server-core
</blockquote>

## `atm0s-media-server-transport-webrtc`

<blockquote>

## [0.3.0-alpha.4](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-transport-webrtc-v0.3.0-alpha.3...atm0s-media-server-transport-webrtc-v0.3.0-alpha.4) - 2026-05-18

### Other

- updated the following local packages: atm0s-media-server-utils, atm0s-media-server-core
</blockquote>

## `atm0s-media-server-runner`

<blockquote>

## [0.1.0-alpha.5](https://github.com/8xFF/atm0s-media-server/compare/atm0s-media-server-runner-v0.1.0-alpha.4...atm0s-media-server-runner-v0.1.0-alpha.5) - 2026-05-18

### Other

- updated the following local packages: atm0s-media-server-connector, atm0s-media-server-core, atm0s-media-server-transport-rtpengine, atm0s-media-server-transport-webrtc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).